### PR TITLE
Feat/split share into import and serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,13 @@ Transfers resume automatically if interrupted — no verified data is re-transfe
 
 ## Install
 
+To build the binary in release mode and install it in your OS default path (e.g. `~/.cargo/bin/rdrop` on Linux and macOS), just run:
+
 ```sh
 cargo install --path .
 ```
+
+After that, `rdrop` is callable from anywhere in the shell without any further configuration.
 
 ## Usage
 
@@ -33,32 +37,48 @@ rdrop id
 ### Manage rings
 
 ```sh
-rdrop ring new                            # create a private ring
-rdrop ring list                           # list all rings
-rdrop ring add <ring-id> <peer-id>        # add a peer to a ring
-rdrop ring remove <ring-id> <peer-id>     # remove a peer from a ring
-rdrop ring members <ring-id>              # list peers of a ring
+rdrop ring new <name>                                        # create a private ring
+rdrop ring list                                              # list all rings
+rdrop ring add <ring-name> <peer-id>                         # add a peer to a ring
+rdrop ring add <ring-name> <peer-id> --nickname "Alice"      # with a display label
+rdrop ring remove <ring-name> <peer-id>                      # remove a peer
+rdrop ring members <ring-name>                               # list peers of a ring
 ```
 
-### Share a file
+### Import a file
+
+`import` adds the file to the blob store and prints an `rdrop://` ticket. It exits immediately — serving is a separate step.
 
 ```sh
-rdrop share file.txt
-rdrop share file.txt --name "my report"
+rdrop import file.txt                              # warns if untagged
+rdrop import file.txt --open                       # publicly accessible
+rdrop import file.txt --tag friends                # restrict to a ring
+rdrop import file.txt --name "my report" --open    # custom ticket name
 ```
 
-This imports the file, prints an `rdrop://` ticket, and keeps the node running to serve downloads. Press `Ctrl-C` to stop serving.
+If no `--tag` or `--open` is given and the file has no existing tags, a warning is printed — the blob won't be transferred until it is tagged.
+If the file was already imported, the existing rings are summarised instead.
 
-### Grant access
+### Grant or change access
 
-Access control is managed separately from sharing. Tag a file with a ring to grant access to its members, or mark it open so anyone with the ticket can download it.
+Tag a file with a ring at any time — before or after importing.
 
 ```sh
-rdrop tag file.txt --ring <uuid>   # restrict to a ring
-rdrop tag file.txt --open          # anyone with the ticket
-rdrop tag <hash>    --ring <uuid>  # same, by hash
-rdrop tag <hash>    --open
+rdrop tag file.txt --ring friends   # restrict to a ring
+rdrop tag file.txt --open           # anyone with the ticket
+rdrop tag <hash>   --ring friends   # same, by BLAKE3 hash
+rdrop tag <hash>   --open
 ```
+
+### Serve
+
+Start the node and serve all authorised blobs until `Ctrl-C`:
+
+```sh
+rdrop serve
+```
+
+Keep this running while peers download. The same node serves every blob that has been tagged — there is no per-file serving step.
 
 ### Receive a file
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ rdrop receive rdrop://ABCDEF... [--dest ./downloads]
 
 Re-run the same command to resume an interrupted transfer.
 
+## Activate more logging
+
+By default only warnings are printed. Set `RUST_LOG` to get more detail:
+
+```sh
+RUST_LOG=ringdrop=info rdrop serve      # info-level logs for all ringdrop code
+RUST_LOG=debug rdrop serve              # debug logs including iroh internals
+```
+
+This applies to every command, not just `serve`.
+
 ## How it works
 
 `ringdrop` is built on top of:

--- a/README.md
+++ b/README.md
@@ -45,18 +45,37 @@ rdrop ring remove <ring-name> <peer-id>                      # remove a peer
 rdrop ring members <ring-name>                               # list peers of a ring
 ```
 
-### Import a file
+### Import and manage files (blobs)
 
-`import` adds the file to the blob store and prints an `rdrop://` ticket. It exits immediately — serving is a separate step.
+`rdrop blob` groups all blob lifecycle operations. `rdrop import` is a shortcut for `rdrop blob import`.
+
+**Import** a file or directory into the local blob store and get a ticket:
 
 ```sh
-rdrop import file.txt              # warns if untagged
-rdrop import file.txt --open       # publicly accessible
-rdrop import file.txt --tag friends   # restrict to a ring
+rdrop import file.txt                    # shortcut — warns if untagged
+rdrop import file.txt --open             # publicly accessible
+rdrop import file.txt --tag friends      # restrict to a ring
+
+rdrop blob import file.txt --open        # same, via blob subcommand
 ```
 
 If no `--tag` or `--open` is given and the file has no existing tags, a warning is printed — the blob won't be transferred until it is tagged.
 If the file was already imported, the existing rings are summarised instead.
+
+**List** all local blobs with their ring tags and share ticket:
+
+```sh
+rdrop blob list
+```
+
+**Remove** a blob from the local store and all its ring tags:
+
+```sh
+rdrop blob remove file.txt
+rdrop blob remove <hash>
+```
+
+Disk space is reclaimed on the next `rdrop serve` run (GC cycle).
 
 ### Grant or change access
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,9 @@ rdrop ring members <ring-name>                               # list peers of a r
 `import` adds the file to the blob store and prints an `rdrop://` ticket. It exits immediately — serving is a separate step.
 
 ```sh
-rdrop import file.txt                              # warns if untagged
-rdrop import file.txt --open                       # publicly accessible
-rdrop import file.txt --tag friends                # restrict to a ring
-rdrop import file.txt --name "my report" --open    # custom ticket name
+rdrop import file.txt              # warns if untagged
+rdrop import file.txt --open       # publicly accessible
+rdrop import file.txt --tag friends   # restrict to a ring
 ```
 
 If no `--tag` or `--open` is given and the file has no existing tags, a warning is printed — the blob won't be transferred until it is tagged.

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -12,7 +12,11 @@ pub enum Cmd {
     #[command(subcommand)]
     Ring(RingCmd),
 
-    /// Import a file/directory into the blob store and print a ticket
+    /// Manage blobs (import, list, remove)
+    #[command(subcommand)]
+    Blob(BlobCmd),
+
+    /// Import a file/directory into the blob store and print a ticket (shortcut for `blob import`)
     Import {
         /// Path to import (file or directory)
         path: PathBuf,
@@ -57,6 +61,28 @@ pub enum Cmd {
 
     /// Print your PeerId so others can add you to their rings
     Id,
+}
+
+#[derive(Subcommand)]
+pub enum BlobCmd {
+    /// Import a file/directory into the blob store and print a ticket
+    Import {
+        /// Path to import (file or directory)
+        path: PathBuf,
+        /// Ring to tag the blob with; if omitted the blob won't be served until tagged
+        #[arg(long, conflicts_with = "open")]
+        tag: Option<String>,
+        /// Tag as publicly accessible (anyone can download); shorthand for --tag open
+        #[arg(long, conflicts_with = "tag")]
+        open: bool,
+    },
+    /// Remove a blob from the local store and all its ring tags
+    Remove {
+        /// File path or BLAKE3 hash (hex)
+        target: String,
+    },
+    /// List all local blobs with their ring tags and share ticket
+    List,
 }
 
 #[derive(Subcommand)]

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -12,17 +12,23 @@ pub enum Cmd {
     #[command(subcommand)]
     Ring(RingCmd),
 
-    /// Import a file/directory and print a ringdrop ticket
-    Share {
-        /// Path to share (file or directory)
+    /// Import a file/directory into the blob store and print a ticket
+    Import {
+        /// Path to import (file or directory)
         path: PathBuf,
         /// Optional human-readable name embedded in the ticket
         #[arg(long)]
         name: Option<String>,
-        /// Exit after the first successful transfer
-        #[arg(long)]
-        oneshot: bool,
+        /// Ring to tag the blob with; if omitted the blob won't be served until tagged
+        #[arg(long, conflicts_with = "open")]
+        tag: Option<String>,
+        /// Tag as publicly accessible (anyone can download); shorthand for --tag open
+        #[arg(long, conflicts_with = "tag")]
+        open: bool,
     },
+
+    /// Start the node and serve all authorised blobs until Ctrl-C
+    Serve,
 
     /// Download a file from a ringdrop ticket (automatically resumes if interrupted)
     Receive {

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -16,9 +16,6 @@ pub enum Cmd {
     Import {
         /// Path to import (file or directory)
         path: PathBuf,
-        /// Optional human-readable name embedded in the ticket
-        #[arg(long)]
-        name: Option<String>,
         /// Ring to tag the blob with; if omitted the blob won't be served until tagged
         #[arg(long, conflicts_with = "open")]
         tag: Option<String>,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,10 +12,16 @@
 //! rdrop ring add friends <peer-id>     # add a peer to a ring
 //! rdrop ring members friends
 //!
-//! # Import a file and get a ticket
+//! # Import a file and get a ticket (shortcut)
 //! rdrop import file.txt                   # untagged — warns until tagged
 //! rdrop import file.txt --open            # publicly accessible
 //! rdrop import file.txt --tag friends     # restrict to a ring
+//!
+//! # Manage blobs
+//! rdrop blob import file.txt --open
+//! rdrop blob list
+//! rdrop blob remove file.txt
+//! rdrop blob remove <hash>
 //!
 //! # Re-tag a blob at any time
 //! rdrop tag file.txt --ring friends
@@ -42,7 +48,7 @@ use crate::core::Node;
 use crate::registry::{Registry, OPEN_RING_NAME};
 use crate::ticket::ShareTicket;
 use crate::util::{default_data_dir, parse_hash};
-use command::Cmd;
+use command::{BlobCmd, Cmd};
 
 #[derive(Parser)]
 #[command(
@@ -85,13 +91,62 @@ async fn resolve_target(target: &str, data_dir: &std::path::Path) -> Result<(Has
     }
 }
 
+async fn run_import(node: &Node, path: PathBuf, tag: Option<String>, open: bool) -> Result<()> {
+    let (hash, format) = import_path(node, &path).await?;
+
+    let tag = if open {
+        Some(OPEN_RING_NAME.to_owned())
+    } else {
+        tag
+    };
+
+    if let Some(ref ring) = tag {
+        node.registry.tag_file(hash, ring)?;
+        if ring == OPEN_RING_NAME {
+            println!("Tagged as open (publicly accessible)");
+        } else {
+            println!("Tagged with ring '{ring}'");
+        }
+    } else {
+        let rings = node.registry.file_rings(hash)?;
+        if rings.is_empty() {
+            println!("Warning: not tagged — this blob won't be served to any peer.");
+            println!("Tag it with:");
+            println!("  rdrop tag {hash} --ring <ring-name>");
+            println!("  rdrop tag {hash} --open");
+        } else {
+            println!("Already tagged:");
+            for r in &rings {
+                if r.is_open() {
+                    println!("  {} (open — publicly accessible)", r.as_str());
+                } else {
+                    println!("  {}", r.as_str());
+                }
+            }
+        }
+    }
+
+    let display_name = path.file_name().map(|n| n.to_string_lossy().into_owned());
+    let ticket = node.make_ticket(hash, format, display_name);
+    let ticket_str = ticket.to_uri()?;
+
+    println!();
+    println!("Ticket:");
+    println!("  {ticket_str}");
+    println!();
+    println!("Run `rdrop serve` to start accepting connections.");
+    println!("Peers receive with:");
+    println!("  rdrop receive {ticket_str}");
+
+    Ok(())
+}
+
 pub async fn run() -> Result<()> {
     let cli = Cli::parse();
 
     fmt()
         .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("warn")),
+            EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("warn")),
         )
         .with_target(false)
         .compact()
@@ -107,54 +162,59 @@ pub async fn run() -> Result<()> {
             command::run_ring(ring_cmd, registry)?;
         }
 
-        Cmd::Import { path, tag, open } => {
-            let node = Node::start(&data_dir).await?;
-            let (hash, format) = import_path(&node, &path).await?;
-
-            let tag = if open {
-                Some(OPEN_RING_NAME.to_owned())
-            } else {
-                tag
-            };
-
-            if let Some(ref ring) = tag {
-                node.registry.tag_file(hash, ring)?;
-                if ring == OPEN_RING_NAME {
-                    println!("Tagged as open (publicly accessible)");
-                } else {
-                    println!("Tagged with ring '{ring}'");
-                }
-            } else {
-                let rings = node.registry.file_rings(hash)?;
-                if rings.is_empty() {
-                    println!("Warning: not tagged — this blob won't be served to any peer.");
-                    println!("Tag it with:");
-                    println!("  rdrop tag {hash} --ring <ring-name>");
-                    println!("  rdrop tag {hash} --open");
-                } else {
-                    println!("Already tagged:");
-                    for r in &rings {
-                        if r.is_open() {
-                            println!("  {} (open — publicly accessible)", r.as_str());
-                        } else {
-                            println!("  {}", r.as_str());
-                        }
-                    }
-                }
+        Cmd::Blob(blob_cmd) => match blob_cmd {
+            BlobCmd::Import { path, tag, open } => {
+                let node = Node::start(&data_dir).await?;
+                run_import(&node, path, tag, open).await?;
+                node.shutdown().await?;
             }
 
-            let display_name = path.file_name().map(|n| n.to_string_lossy().into_owned());
-            let ticket = node.make_ticket(hash, format, display_name);
-            let ticket_str = ticket.to_uri()?;
+            BlobCmd::Remove { target } => {
+                let node = Node::start(&data_dir).await?;
+                let path = PathBuf::from(&target);
+                let hash = if path.exists() {
+                    let (hash, _) = import_path(&node, &path).await?;
+                    hash
+                } else {
+                    parse_hash(&target)?
+                };
+                node.registry.remove_file_tags(hash)?;
+                node.delete_blob(hash).await?;
+                println!("Removed {hash}");
+                println!("Disk space will be reclaimed on the next `rdrop serve` run.");
+                node.shutdown().await?;
+            }
 
-            println!();
-            println!("Ticket:");
-            println!("  {ticket_str}");
-            println!();
-            println!("Run `rdrop serve` to start accepting connections.");
-            println!("Peers receive with:");
-            println!("  rdrop receive {ticket_str}");
+            BlobCmd::List => {
+                let node = Node::start(&data_dir).await?;
+                let blobs = node.list_blobs().await?;
+                if blobs.is_empty() {
+                    println!("No blobs in local store.");
+                } else {
+                    println!("{} blob(s):", blobs.len());
+                    for (hash, format) in blobs {
+                        let rings = node.registry.file_rings(hash)?;
+                        let ticket = node.make_ticket(hash, format, None);
+                        let ticket_str = ticket.to_uri()?;
+                        println!();
+                        println!("  {hash}");
+                        if rings.is_empty() {
+                            println!("    rings:  (none — not accessible to any peer)");
+                        } else {
+                            let names: Vec<_> =
+                                rings.iter().map(|r| r.as_str().to_owned()).collect();
+                            println!("    rings:  {}", names.join(", "));
+                        }
+                        println!("    ticket: {ticket_str}");
+                    }
+                }
+                node.shutdown().await?;
+            }
+        },
 
+        Cmd::Import { path, tag, open } => {
+            let node = Node::start(&data_dir).await?;
+            run_import(&node, path, tag, open).await?;
             node.shutdown().await?;
         }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -35,6 +35,7 @@ use std::path::PathBuf;
 use anyhow::{Context, Result};
 use clap::Parser;
 use iroh_blobs::{BlobFormat, Hash};
+use tracing_subscriber::{fmt, EnvFilter};
 
 use crate::config::Config;
 use crate::core::Node;
@@ -86,6 +87,16 @@ async fn resolve_target(target: &str, data_dir: &std::path::Path) -> Result<(Has
 
 pub async fn run() -> Result<()> {
     let cli = Cli::parse();
+
+    fmt()
+        .with_env_filter(
+            EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| EnvFilter::new("warn")),
+        )
+        .with_target(false)
+        .compact()
+        .init();
+
     let data_dir = cli.data_dir.unwrap_or_else(default_data_dir);
 
     match cli.command {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -12,18 +12,20 @@
 //! rdrop ring add friends <peer-id>     # add a peer to a ring
 //! rdrop ring members friends
 //!
-//! # Share a file and get a ticket
-//! rdrop share file.txt
-//! rdrop share file.txt --name "my report"
+//! # Import a file and get a ticket
+//! rdrop import file.txt                              # untagged — warns until tagged
+//! rdrop import file.txt --open                       # publicly accessible
+//! rdrop import file.txt --name "my report" --tag friends
+//!
+//! # Re-tag a blob at any time
+//! rdrop tag file.txt --ring friends
+//! rdrop tag <hash> --open
+//!
+//! # Start serving all authorised blobs
+//! rdrop serve
 //!
 //! # Receive — resumes automatically if interrupted
 //! rdrop receive rdrop://ABCDEF... [--dest ./downloads]
-//!
-//! # Grant access to a shared file (by path or hash)
-//! rdrop tag file.txt --ring friends
-//! rdrop tag file.txt --open
-//! rdrop tag <hash> --ring friends
-//! rdrop tag <hash> --open
 //! ```
 
 mod command;
@@ -94,13 +96,37 @@ pub async fn run() -> Result<()> {
             command::run_ring(ring_cmd, registry)?;
         }
 
-        Cmd::Share {
-            path,
-            name,
-            oneshot,
-        } => {
+        Cmd::Import { path, name, tag, open } => {
             let node = Node::start(&data_dir).await?;
             let (hash, format) = import_path(&node, &path).await?;
+
+            let tag = if open { Some(OPEN_RING_NAME.to_owned()) } else { tag };
+
+            if let Some(ref ring) = tag {
+                node.registry.tag_file(hash, ring)?;
+                if ring == OPEN_RING_NAME {
+                    println!("Tagged as open (publicly accessible)");
+                } else {
+                    println!("Tagged with ring '{ring}'");
+                }
+            } else {
+                let rings = node.registry.file_rings(hash)?;
+                if rings.is_empty() {
+                    println!("Warning: not tagged — this blob won't be served to any peer.");
+                    println!("Tag it with:");
+                    println!("  rdrop tag {hash} --ring <ring-name>");
+                    println!("  rdrop tag {hash} --open");
+                } else {
+                    println!("Already tagged:");
+                    for r in &rings {
+                        if r.is_open() {
+                            println!("  {} (open — publicly accessible)", r.as_str());
+                        } else {
+                            println!("  {}", r.as_str());
+                        }
+                    }
+                }
+            }
 
             let display_name =
                 name.or_else(|| path.file_name().map(|n| n.to_string_lossy().into_owned()));
@@ -108,36 +134,21 @@ pub async fn run() -> Result<()> {
             let ticket_str = ticket.to_uri()?;
 
             println!();
-            println!("Ticket (give this to peers):");
+            println!("Ticket:");
             println!("  {ticket_str}");
             println!();
-            println!("They can receive the file with:");
+            println!("Run `rdrop serve` to start accepting connections.");
+            println!("Peers receive with:");
             println!("  rdrop receive {ticket_str}");
-            println!();
-            println!("Grant access with:");
-            println!(
-                "  rdrop tag {} --ring <ring-name>  # private ring",
-                path.display()
-            );
-            println!(
-                "  rdrop tag {} --open               # anyone",
-                path.display()
-            );
-            println!();
-            if oneshot {
-                println!("Serving… (exits after first successful transfer, or Ctrl-C to stop)");
-                let transfer_done = node.transfer_done();
-                tokio::select! {
-                    _ = tokio::signal::ctrl_c() => {},
-                    _ = transfer_done.notified() => {
-                        println!("Transfer complete. Exiting.");
-                    },
-                }
-            } else {
-                println!("Serving… (Ctrl-C to stop)");
-                tokio::signal::ctrl_c().await?;
-            }
 
+            node.shutdown().await?;
+        }
+
+        Cmd::Serve => {
+            let node = Node::start(&data_dir).await?;
+            println!("Node online. Peer ID: {}", node.peer_id());
+            println!("Serving all authorised blobs — Ctrl-C to stop.");
+            tokio::signal::ctrl_c().await?;
             node.shutdown().await?;
         }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,9 +13,9 @@
 //! rdrop ring members friends
 //!
 //! # Import a file and get a ticket
-//! rdrop import file.txt                              # untagged — warns until tagged
-//! rdrop import file.txt --open                       # publicly accessible
-//! rdrop import file.txt --name "my report" --tag friends
+//! rdrop import file.txt                   # untagged — warns until tagged
+//! rdrop import file.txt --open            # publicly accessible
+//! rdrop import file.txt --tag friends     # restrict to a ring
 //!
 //! # Re-tag a blob at any time
 //! rdrop tag file.txt --ring friends
@@ -96,11 +96,15 @@ pub async fn run() -> Result<()> {
             command::run_ring(ring_cmd, registry)?;
         }
 
-        Cmd::Import { path, name, tag, open } => {
+        Cmd::Import { path, tag, open } => {
             let node = Node::start(&data_dir).await?;
             let (hash, format) = import_path(&node, &path).await?;
 
-            let tag = if open { Some(OPEN_RING_NAME.to_owned()) } else { tag };
+            let tag = if open {
+                Some(OPEN_RING_NAME.to_owned())
+            } else {
+                tag
+            };
 
             if let Some(ref ring) = tag {
                 node.registry.tag_file(hash, ring)?;
@@ -128,8 +132,7 @@ pub async fn run() -> Result<()> {
                 }
             }
 
-            let display_name =
-                name.or_else(|| path.file_name().map(|n| n.to_string_lossy().into_owned()));
+            let display_name = path.file_name().map(|n| n.to_string_lossy().into_owned());
             let ticket = node.make_ticket(hash, format, display_name);
             let ticket_str = ticket.to_uri()?;
 

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -31,7 +31,7 @@ use iroh_blobs::{
     api::blobs::{AddPathOptions, BlobStatus, ImportMode},
     format::collection::Collection,
     store::fs::FsStore,
-    BlobFormat, BlobsProtocol, Hash,
+    BlobFormat, Hash,
 };
 use tracing::info;
 use walkdir::WalkDir;
@@ -72,11 +72,9 @@ impl Node {
             .context("opening registry")?;
 
         let gate = RingGate::new(registry.clone(), store.clone());
-        let blobs_proto = BlobsProtocol::new(&store, None);
 
         let router = Router::builder(endpoint.clone())
             .accept(SC_ALPN, gate)
-            .accept(iroh_blobs::ALPN, blobs_proto)
             .spawn();
 
         endpoint.online().await;

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -26,13 +26,15 @@ use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use bao_tree::ChunkRanges;
+use futures_lite::StreamExt;
 use iroh::{endpoint::presets, protocol::Router, Endpoint, EndpointAddr, EndpointId};
 use iroh_blobs::{
     api::blobs::{AddPathOptions, BlobStatus, ImportMode},
     format::collection::Collection,
-    store::fs::FsStore,
-    BlobFormat, Hash,
+    store::{fs::FsStore, GcConfig},
+    BlobFormat, Hash, HashAndFormat,
 };
+use std::time::Duration;
 use tracing::info;
 use walkdir::WalkDir;
 
@@ -66,7 +68,15 @@ impl Node {
         //   <hash>.obao4    — flattened BLAKE3 hash tree (16 KiB chunk groups)
         //   <hash>.bitfield — bitmask of validated chunk groups (crash-safe)
         let blobs_dir = data_dir.join("blobs");
-        let store = FsStore::load(&blobs_dir).await.context("loading FsStore")?;
+        let db_path = blobs_dir.join("blobs.db");
+        let mut fs_opts = iroh_blobs::store::fs::options::Options::new(&blobs_dir);
+        fs_opts.gc = Some(GcConfig {
+            interval: Duration::from_secs(30),
+            add_protected: None,
+        });
+        let store = FsStore::load_with_opts(db_path, fs_opts)
+            .await
+            .context("loading FsStore")?;
 
         let registry = Registry::open(data_dir.join("registry.redb"), endpoint.id())
             .context("opening registry")?;
@@ -109,8 +119,16 @@ impl Node {
             .temp_tag()
             .await
             .context("add_path")?;
-        info!(hash = %tag.hash(), "imported — outboard computed");
-        Ok((tag.hash(), BlobFormat::Raw))
+        let hash = tag.hash();
+        let format = BlobFormat::Raw;
+        // Persist: replace temp tag with a named tag so GC won't collect this blob.
+        self.store
+            .tags()
+            .set(hash.to_string(), HashAndFormat { hash, format })
+            .await
+            .context("pinning blob tag")?;
+        info!(%hash, "imported — outboard computed");
+        Ok((hash, format))
     }
 
     pub async fn import_directory(&self, dir: impl AsRef<Path>) -> Result<(Hash, BlobFormat)> {
@@ -150,8 +168,38 @@ impl Node {
         }
 
         let col_tag = collection.store(&self.store).await?;
-        info!(hash = %col_tag.hash(), "collection stored");
-        Ok((col_tag.hash(), BlobFormat::HashSeq))
+        let hash = col_tag.hash();
+        let format = BlobFormat::HashSeq;
+        // Persist: named tag on the collection; GC follows HashSeq refs to keep member blobs.
+        self.store
+            .tags()
+            .set(hash.to_string(), HashAndFormat { hash, format })
+            .await
+            .context("pinning collection tag")?;
+        info!(%hash, "collection stored");
+        Ok((hash, format))
+    }
+
+    /// List all blobs that have been imported (hash + format).
+    pub async fn list_blobs(&self) -> Result<Vec<(Hash, BlobFormat)>> {
+        let mut stream = self.store.tags().list().await?;
+        let mut blobs = Vec::new();
+        while let Some(item) = stream.next().await {
+            let info = item?;
+            blobs.push((info.hash, info.format));
+        }
+        Ok(blobs)
+    }
+
+    /// Remove a blob from the store. Ring tags must be removed separately via the registry.
+    /// Actual disk reclamation happens on the next GC cycle (during `rdrop serve`).
+    pub async fn delete_blob(&self, hash: Hash) -> Result<()> {
+        self.store
+            .tags()
+            .delete(hash.to_string())
+            .await
+            .context("removing blob tag")?;
+        Ok(())
     }
 
     pub fn make_ticket(&self, hash: Hash, format: BlobFormat, name: Option<String>) -> ShareTicket {

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -22,10 +22,7 @@
 //! 5. If the connection drops again, step 1 picks up from the last committed
 //!    chunk group — no already-verified data is re-transferred.
 
-use std::{
-    path::{Path, PathBuf},
-    sync::Arc,
-};
+use std::path::{Path, PathBuf};
 
 use anyhow::{bail, Context, Result};
 use bao_tree::ChunkRanges;
@@ -36,7 +33,6 @@ use iroh_blobs::{
     store::fs::FsStore,
     BlobFormat, BlobsProtocol, Hash,
 };
-use tokio::sync::Notify;
 use tracing::info;
 use walkdir::WalkDir;
 
@@ -50,7 +46,6 @@ pub struct Node {
     pub store: FsStore,
     pub registry: Registry,
     router: Router,
-    transfer_done: Arc<Notify>,
 }
 
 impl Node {
@@ -76,7 +71,7 @@ impl Node {
         let registry = Registry::open(data_dir.join("registry.redb"), endpoint.id())
             .context("opening registry")?;
 
-        let (gate, transfer_done) = RingGate::new(registry.clone(), store.clone());
+        let gate = RingGate::new(registry.clone(), store.clone());
         let blobs_proto = BlobsProtocol::new(&store, None);
 
         let router = Router::builder(endpoint.clone())
@@ -92,7 +87,6 @@ impl Node {
             store,
             registry,
             router,
-            transfer_done,
         })
     }
 
@@ -101,9 +95,6 @@ impl Node {
     }
     pub fn node_addr(&self) -> EndpointAddr {
         self.endpoint.addr()
-    }
-    pub fn transfer_done(&self) -> Arc<Notify> {
-        self.transfer_done.clone()
     }
 
     pub async fn import_file(&self, path: impl AsRef<Path>) -> Result<(Hash, BlobFormat)> {

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -20,7 +20,7 @@
 //!            enabling the receiver to verify each chunk independently.
 //! ```
 
-use std::{fmt, io, sync::Arc};
+use std::{fmt, io};
 
 use anyhow::{bail, Context, Result};
 use bao_tree::{ChunkNum, ChunkRanges};
@@ -32,7 +32,6 @@ use iroh::{
 };
 use iroh_blobs::{store::fs::FsStore, Hash};
 use iroh_io::AsyncStreamWriter;
-use tokio::sync::Notify;
 use tracing::{debug, info, warn};
 
 use crate::registry::Registry;
@@ -118,7 +117,6 @@ fn decode_ranges_wire(count: u32, raw: &[u8]) -> Result<ChunkRanges> {
 pub(super) struct RingGate {
     registry: Registry,
     store: FsStore,
-    transfer_done: Arc<Notify>,
 }
 
 impl fmt::Debug for RingGate {
@@ -128,14 +126,8 @@ impl fmt::Debug for RingGate {
 }
 
 impl RingGate {
-    pub(super) fn new(registry: Registry, store: FsStore) -> (Self, Arc<Notify>) {
-        let transfer_done = Arc::new(Notify::new());
-        let gate = RingGate {
-            registry,
-            store,
-            transfer_done: transfer_done.clone(),
-        };
-        (gate, transfer_done)
+    pub(super) fn new(registry: Registry, store: FsStore) -> Self {
+        RingGate { registry, store }
     }
 }
 
@@ -218,7 +210,6 @@ impl RingGate {
         send.finish()?;
 
         info!(%peer, %hash, "done");
-        self.transfer_done.notify_one();
         Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,16 +1,6 @@
 use anyhow::Result;
-use tracing_subscriber::{fmt, EnvFilter};
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    fmt()
-        .with_env_filter(
-            EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| EnvFilter::new("ringdrop=info,warn")),
-        )
-        .with_target(false)
-        .compact()
-        .init();
-
     ringdrop::cli::run().await
 }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -183,6 +183,17 @@ impl Registry {
         Ok(ids)
     }
 
+    /// Remove all ring tags for a blob (used when deleting a blob).
+    pub fn remove_file_tags(&self, hash: Hash) -> Result<()> {
+        let write = self.db.begin_write()?;
+        {
+            let mut table = write.open_table(FILE_RINGS)?;
+            table.remove(hash.as_bytes().as_slice())?;
+        }
+        write.commit()?;
+        Ok(())
+    }
+
     /// Return all rings a blob is tagged with.
     pub fn file_rings(&self, hash: Hash) -> Result<Vec<RingId>> {
         let read = self.db.begin_read()?;


### PR DESCRIPTION
Refactor the `Share` command splitting it into two:

- A `Import` subcommand, get a target file into the blob store and generate a download ticket for that specific hash;
- A `Serve` subcommad, to start listening to any incoming peer authorized for downloads (not just the one in a particular ticket.

Also add a new subcommand, namely `Blob` to organise files on the blob store. It should support `import`, `remove` and `list`.