### PR TITLE
refactor(PeerId): Harmonize peer-id presence and verifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ After installation, `rdrop` is available from anywhere in your shell. If it isn'
 
 ### Print your `peer-id`
 
-Share your `peer-id` with others so they can add you to their rings:
+Share your `peer-id` (i.e. your node public id) with others so they can add you to their rings:
 
 ```sh
 rdrop id

--- a/src/cli/command.rs
+++ b/src/cli/command.rs
@@ -1,7 +1,8 @@
 use std::path::PathBuf;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use clap::{ArgGroup, Subcommand};
+use iroh::EndpointId;
 
 use crate::registry::{Registry, OPEN_RING_NAME};
 use crate::util::parse_peer_id;
@@ -59,7 +60,7 @@ pub enum Cmd {
         target: String,
     },
 
-    /// Print your PeerId so others can add you to their rings
+    /// Print your peer-id (this node public-id) so others can add you to their rings
     Id,
 }
 
@@ -113,7 +114,7 @@ pub enum RingCmd {
     Members { ring: String },
 }
 
-pub fn run_ring(cmd: RingCmd, registry: Registry) -> Result<()> {
+pub fn run_ring(cmd: RingCmd, registry: Registry, public_id: EndpointId) -> Result<()> {
     match cmd {
         RingCmd::New { name } => {
             registry.create_ring(&name)?;
@@ -145,6 +146,9 @@ pub fn run_ring(cmd: RingCmd, registry: Registry) -> Result<()> {
                 return Ok(());
             }
             let peer = parse_peer_id(&peer)?;
+            if peer == public_id {
+                return Err(anyhow!("cannot add yourself to a ring"));
+            }
             registry.add_member(&ring, peer, nickname.as_deref())?;
             match &nickname {
                 Some(nick) => println!("Added {peer} ({nick}) to ring {ring}"),

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -78,15 +78,15 @@ async fn resolve_target(target: &str, data_dir: &std::path::Path) -> Result<(Has
     tokio::fs::create_dir_all(data_dir).await?;
     let path = PathBuf::from(target);
     if path.exists() {
-        let node = Node::start(data_dir).await?;
+        let cfg = Config::load_or_create(data_dir).context("loading config")?;
+        let node = Node::start(data_dir, cfg).await?;
         let (hash, _) = import_path(&node, &path).await?;
         let registry = node.registry.clone();
         node.shutdown().await?;
         Ok((hash, registry))
     } else {
         let hash = parse_hash(target)?;
-        let cfg = Config::load_or_create(data_dir).context("loading config")?;
-        let registry = Registry::open(data_dir.join("registry.redb"), cfg.secret_key.public())?;
+        let registry = Registry::open(data_dir.join("registry.redb"))?;
         Ok((hash, registry))
     }
 }
@@ -158,19 +158,22 @@ pub async fn run() -> Result<()> {
         Cmd::Ring(ring_cmd) => {
             tokio::fs::create_dir_all(&data_dir).await?;
             let cfg = Config::load_or_create(&data_dir).context("loading config")?;
-            let registry = Registry::open(data_dir.join("registry.redb"), cfg.secret_key.public())?;
-            command::run_ring(ring_cmd, registry)?;
+            let public_id = cfg.public_id();
+            let registry = Registry::open(data_dir.join("registry.redb"))?;
+            command::run_ring(ring_cmd, registry, public_id)?;
         }
 
         Cmd::Blob(blob_cmd) => match blob_cmd {
             BlobCmd::Import { path, tag, open } => {
-                let node = Node::start(&data_dir).await?;
+                let cfg = Config::load_or_create(&data_dir).context("loading config")?;
+                let node = Node::start(&data_dir, cfg).await?;
                 run_import(&node, path, tag, open).await?;
                 node.shutdown().await?;
             }
 
             BlobCmd::Remove { target } => {
-                let node = Node::start(&data_dir).await?;
+                let cfg = Config::load_or_create(&data_dir).context("loading config")?;
+                let node = Node::start(&data_dir, cfg).await?;
                 let path = PathBuf::from(&target);
                 let hash = if path.exists() {
                     let (hash, _) = import_path(&node, &path).await?;
@@ -186,7 +189,8 @@ pub async fn run() -> Result<()> {
             }
 
             BlobCmd::List => {
-                let node = Node::start(&data_dir).await?;
+                let cfg = Config::load_or_create(&data_dir).context("loading config")?;
+                let node = Node::start(&data_dir, cfg).await?;
                 let blobs = node.list_blobs().await?;
                 if blobs.is_empty() {
                     println!("No blobs in local store.");
@@ -213,14 +217,17 @@ pub async fn run() -> Result<()> {
         },
 
         Cmd::Import { path, tag, open } => {
-            let node = Node::start(&data_dir).await?;
+            let cfg = Config::load_or_create(&data_dir).context("loading config")?;
+            let node = Node::start(&data_dir, cfg).await?;
             run_import(&node, path, tag, open).await?;
             node.shutdown().await?;
         }
 
         Cmd::Share => {
-            let node = Node::start(&data_dir).await?;
-            println!("Node online. Peer ID: {}", node.peer_id());
+            let cfg = Config::load_or_create(&data_dir).context("loading config")?;
+            let public_id = cfg.public_id();
+            let node = Node::start(&data_dir, cfg).await?;
+            println!("Node online. Peer ID: {public_id}");
             println!("Sharing all authorised blobs — Ctrl-C to stop.");
             tokio::signal::ctrl_c().await?;
             node.shutdown().await?;
@@ -228,7 +235,9 @@ pub async fn run() -> Result<()> {
 
         Cmd::Receive { ticket, dest } => {
             let ticket = ShareTicket::from_uri(&ticket)?;
-            let node = Node::start(&data_dir).await?;
+            let cfg = Config::load_or_create(&data_dir).context("loading config")?;
+            let public_id = cfg.public_id();
+            let node = Node::start(&data_dir, cfg).await?;
 
             println!(
                 "Fetching {} from {}{}",
@@ -249,9 +258,9 @@ pub async fn run() -> Result<()> {
                     eprintln!("Transfer failed: {e:#}");
                     if e.to_string().contains("access denied") {
                         eprintln!();
-                        eprintln!("Your PeerId: {}", node.peer_id());
+                        eprintln!("Your PeerId: {public_id}");
                         eprintln!("Ask the file owner to run:");
-                        eprintln!("  rdrop ring add <ring-name> {}", node.peer_id());
+                        eprintln!("  rdrop ring add <ring-name> {public_id}");
                     }
                     std::process::exit(1);
                 }
@@ -296,9 +305,9 @@ pub async fn run() -> Result<()> {
         }
 
         Cmd::Id => {
-            let node = Node::start(&data_dir).await?;
-            println!("{}", node.peer_id());
-            node.shutdown().await?;
+            tokio::fs::create_dir_all(&data_dir).await?;
+            let cfg = Config::load_or_create(&data_dir).context("loading config")?;
+            println!("{}", cfg.public_id());
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use iroh::SecretKey;
+use iroh::{EndpointId, SecretKey};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -10,6 +10,10 @@ pub struct Config {
 }
 
 impl Config {
+    pub fn public_id(&self) -> EndpointId {
+        self.secret_key.public()
+    }
+
     pub fn load_or_create(data_dir: &Path) -> Result<Self> {
         let path = data_dir.join("config.json");
         if path.exists() {

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -27,7 +27,7 @@ use std::path::{Path, PathBuf};
 use anyhow::{bail, Context, Result};
 use bao_tree::ChunkRanges;
 use futures_lite::StreamExt;
-use iroh::{endpoint::presets, protocol::Router, Endpoint, EndpointAddr, EndpointId};
+use iroh::{endpoint::presets, protocol::Router, Endpoint, EndpointAddr};
 use iroh_blobs::{
     api::blobs::{AddPathOptions, BlobStatus, ImportMode},
     format::collection::Collection,
@@ -51,11 +51,10 @@ pub struct Node {
 }
 
 impl Node {
-    pub async fn start(data_dir: impl AsRef<Path>) -> Result<Self> {
+    pub async fn start(data_dir: impl AsRef<Path>, cfg: Config) -> Result<Self> {
         let data_dir = data_dir.as_ref().to_path_buf();
         tokio::fs::create_dir_all(&data_dir).await?;
 
-        let cfg = Config::load_or_create(&data_dir).context("loading config")?;
         let endpoint = Endpoint::builder(presets::N0)
             .secret_key(cfg.secret_key)
             .bind()
@@ -78,8 +77,8 @@ impl Node {
             .await
             .context("loading FsStore")?;
 
-        let registry = Registry::open(data_dir.join("registry.redb"), endpoint.id())
-            .context("opening registry")?;
+        let registry =
+            Registry::open(data_dir.join("registry.redb")).context("opening registry")?;
 
         let gate = RingGate::new(registry.clone(), store.clone());
 
@@ -98,9 +97,6 @@ impl Node {
         })
     }
 
-    pub fn peer_id(&self) -> EndpointId {
-        self.endpoint.id()
-    }
     pub fn node_addr(&self) -> EndpointAddr {
         self.endpoint.addr()
     }
@@ -259,7 +255,7 @@ impl Node {
             Status::Denied => bail!(
                 "access denied — not in a ring for this blob.\n\
                  Your PeerId: {}",
-                self.peer_id()
+                self.endpoint.id()
             ),
             Status::Allowed => {}
         }

--- a/src/registry/mod.rs
+++ b/src/registry/mod.rs
@@ -42,7 +42,6 @@ const NICKNAMES: TableDefinition<&[u8], &str> = TableDefinition::new("nicknames"
 #[derive(Clone)]
 pub struct Registry {
     db: Arc<Database>,
-    self_id: EndpointId,
 }
 
 impl Registry {
@@ -52,7 +51,7 @@ impl Registry {
     /// to add oneself to a ring.
     ///
     /// On first creation the open ring is bootstrapped automatically.
-    pub fn open(path: impl AsRef<Path>, self_id: EndpointId) -> Result<Self> {
+    pub fn open(path: impl AsRef<Path>) -> Result<Self> {
         let db = Database::create(path)?;
         let write = db.begin_write()?;
         {
@@ -65,10 +64,7 @@ impl Registry {
             }
         }
         write.commit()?;
-        Ok(Registry {
-            db: Arc::new(db),
-            self_id,
-        })
+        Ok(Registry { db: Arc::new(db) })
     }
 
     /// Create a new ring with the given name.
@@ -103,9 +99,6 @@ impl Registry {
     ///
     /// Returns an error if `peer` is the local node's own peer ID.
     pub fn add_member(&self, ring: &str, peer: EndpointId, nickname: Option<&str>) -> Result<()> {
-        if peer == self.self_id {
-            return Err(anyhow!("cannot add yourself to a ring"));
-        }
         let write = self.db.begin_write()?;
         {
             let mut table = write.open_table(RINGS)?;
@@ -324,13 +317,10 @@ mod tests {
     use super::*;
     use tempfile::tempdir;
 
-    /// Returns `(registry, self_id, tempdir)`.
-    /// `self_id` is the local peer ID baked into this registry instance.
-    fn make_registry() -> (Registry, EndpointId, tempfile::TempDir) {
+    fn make_registry() -> (Registry, tempfile::TempDir) {
         let dir = tempdir().unwrap();
-        let self_id = iroh::SecretKey::generate().public();
-        let reg = Registry::open(dir.path().join("test.redb"), self_id).unwrap();
-        (reg, self_id, dir)
+        let reg = Registry::open(dir.path().join("test.redb")).unwrap();
+        (reg, dir)
     }
 
     fn make_hash(b: u8) -> Hash {
@@ -345,7 +335,7 @@ mod tests {
 
     #[test]
     fn tag_open_ring_clears_private_rings() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let hash = make_hash(1);
         reg.create_ring("friends").unwrap();
 
@@ -358,7 +348,7 @@ mod tests {
 
     #[test]
     fn tag_private_ring_clears_open_ring() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let hash = make_hash(1);
         reg.create_ring("friends").unwrap();
 
@@ -371,7 +361,7 @@ mod tests {
 
     #[test]
     fn tag_private_ring_is_idempotent() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let hash = make_hash(1);
         reg.create_ring("friends").unwrap();
 
@@ -383,7 +373,7 @@ mod tests {
 
     #[test]
     fn tag_multiple_private_rings_accumulate() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let hash = make_hash(1);
         reg.create_ring("friends").unwrap();
         reg.create_ring("work").unwrap();
@@ -399,7 +389,7 @@ mod tests {
 
     #[test]
     fn tag_file_rejects_nonexistent_ring() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let hash = make_hash(1);
         assert!(reg.tag_file(hash, "ghost").is_err());
     }
@@ -408,7 +398,7 @@ mod tests {
 
     #[test]
     fn file_rings_untagged_blob_returns_empty() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         assert_eq!(reg.file_rings(make_hash(1)).unwrap(), vec![]);
     }
 
@@ -416,33 +406,33 @@ mod tests {
 
     #[test]
     fn create_ring_rejects_reserved_name() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         assert!(reg.create_ring(OPEN_RING_NAME).is_err());
     }
 
     #[test]
     fn create_ring_rejects_duplicate() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         reg.create_ring("friends").unwrap();
         assert!(reg.create_ring("friends").is_err());
     }
 
     #[test]
     fn create_ring_rejects_empty_name() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         assert!(reg.create_ring("").is_err());
     }
 
     #[test]
     fn create_ring_rejects_name_with_whitespace() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         assert!(reg.create_ring("my ring").is_err());
         assert!(reg.create_ring("tab\there").is_err());
     }
 
     #[test]
     fn create_ring_rejects_name_with_nul() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         assert!(reg.create_ring("ring\0name").is_err());
     }
 
@@ -450,14 +440,14 @@ mod tests {
 
     #[test]
     fn list_rings_always_includes_open_ring() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let rings = reg.list_rings().unwrap();
         assert_eq!(rings[0], RingId::open());
     }
 
     #[test]
     fn list_rings_returns_all_created_rings() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         reg.create_ring("friends").unwrap();
         reg.create_ring("work").unwrap();
 
@@ -470,16 +460,8 @@ mod tests {
     // add_member / remove_member
 
     #[test]
-    fn add_member_rejects_self_peer_id() {
-        let (reg, self_id, _dir) = make_registry();
-        reg.create_ring("friends").unwrap();
-        let err = reg.add_member("friends", self_id, None).unwrap_err();
-        assert!(err.to_string().contains("yourself"));
-    }
-
-    #[test]
     fn add_member_is_idempotent() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let peer = make_peer_id();
         reg.create_ring("friends").unwrap();
 
@@ -491,21 +473,21 @@ mod tests {
 
     #[test]
     fn add_member_to_nonexistent_ring_errors() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let peer = make_peer_id();
         assert!(reg.add_member("ghost", peer, None).is_err());
     }
 
     #[test]
     fn remove_member_from_nonexistent_ring_errors() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let peer = make_peer_id();
         assert!(reg.remove_member("ghost", peer).is_err());
     }
 
     #[test]
     fn remove_member_noop_when_peer_not_in_ring() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let peer = make_peer_id();
         reg.create_ring("friends").unwrap();
 
@@ -518,7 +500,7 @@ mod tests {
 
     #[test]
     fn list_members_nonexistent_ring_errors() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         assert!(reg.list_members("ghost").is_err());
     }
 
@@ -526,14 +508,14 @@ mod tests {
 
     #[test]
     fn is_allowed_untagged_blob_denied() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let peer = make_peer_id();
         assert!(!reg.is_allowed(&peer, &make_hash(1)).unwrap());
     }
 
     #[test]
     fn is_allowed_open_ring_permits_any_peer() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let hash = make_hash(1);
         let peer = make_peer_id();
 
@@ -543,7 +525,7 @@ mod tests {
 
     #[test]
     fn is_allowed_member_of_tagged_ring_permitted() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let hash = make_hash(1);
         let peer = make_peer_id();
         reg.create_ring("friends").unwrap();
@@ -556,7 +538,7 @@ mod tests {
 
     #[test]
     fn is_allowed_non_member_denied() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let hash = make_hash(1);
         let member = make_peer_id();
         let stranger = make_peer_id();
@@ -570,7 +552,7 @@ mod tests {
 
     #[test]
     fn is_allowed_peer_in_one_of_multiple_tagged_rings_permitted() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let hash = make_hash(1);
         let peer = make_peer_id();
         reg.create_ring("friends").unwrap();
@@ -588,7 +570,7 @@ mod tests {
 
     #[test]
     fn nickname_stored_and_returned_by_list_members() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let peer = make_peer_id();
         reg.create_ring("friends").unwrap();
 
@@ -602,7 +584,7 @@ mod tests {
 
     #[test]
     fn no_nickname_returns_none() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let peer = make_peer_id();
         reg.create_ring("friends").unwrap();
 
@@ -614,7 +596,7 @@ mod tests {
 
     #[test]
     fn nickname_updated_on_readd() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let peer = make_peer_id();
         reg.create_ring("friends").unwrap();
 
@@ -628,7 +610,7 @@ mod tests {
 
     #[test]
     fn nickname_removed_with_peer() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let peer = make_peer_id();
         reg.create_ring("friends").unwrap();
 
@@ -642,7 +624,7 @@ mod tests {
 
     #[test]
     fn nicknames_are_per_ring() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let peer = make_peer_id();
         reg.create_ring("friends").unwrap();
         reg.create_ring("work").unwrap();
@@ -658,7 +640,7 @@ mod tests {
 
     #[test]
     fn members_mixed_nicknames_and_none() {
-        let (reg, _self_id, _dir) = make_registry();
+        let (reg, _dir) = make_registry();
         let alice = make_peer_id();
         let bob = make_peer_id();
         reg.create_ring("friends").unwrap();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+use ringdrop::config::Config;
 use ringdrop::core::Node;
 use tempfile::TempDir;
 use tokio::fs;
@@ -12,7 +13,8 @@ pub struct TestNode {
 impl TestNode {
     pub async fn start() -> Self {
         let dir = TempDir::new().expect("tempdir");
-        let node = Node::start(dir.path()).await.expect("node start");
+        let cfg = Config::load_or_create(dir.path()).expect("config");
+        let node = Node::start(dir.path(), cfg).await.expect("node start");
         TestNode { node, _dir: dir }
     }
 

--- a/tests/ring_gate.rs
+++ b/tests/ring_gate.rs
@@ -42,7 +42,7 @@ async fn private_ring_allows_member() {
     sender
         .node
         .registry
-        .add_member("friends", receiver.node.peer_id(), None)
+        .add_member("friends", receiver.node.endpoint.id(), None)
         .unwrap();
     sender.node.registry.tag_file(hash, "friends").unwrap();
 


### PR DESCRIPTION
Resolves #4

The node public id (or self peer id) is no more set in the `Registry` but directly taken from the `Config::public_id()` method (i.e. inner call to `secret_key.public()`), which is fast : a single Ed25519 scalar multiplication to derive the public key from the private key, no I/O, no allocation beyond 32 bytes.

The following holds:
- The peer id existence is enforced at any CLI command run;
- The `Registry` stays focused on its responsibility only: atomic data persistence ;
- The secret key (ancestor of the peer id) is generated and stored (if it's not already present in the config.json) at the very first command run.