### PR TITLE
docs: update install section with platform-specific instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,19 @@ Access control is enforced at the connection level via an ALPN protocol (`/iroh-
 
 ## Install
 
-**From source (Linux / macOS):**
+**macOS:**
 
 ```sh
-curl -fsSL https://raw.githubusercontent.com/rikettsie/ringdrop/main/install.sh | bash
+brew install ringdrop
 ```
 
-**If you already have Rust installed:**
+**Windows:**
+
+```sh
+scoop install ringdrop
+```
+
+**Linux (and from source in general):**
 
 ```sh
 cargo install ringdrop


### PR DESCRIPTION
## Summary

Updated the Install section in README.md to describe platform-specific installation methods as requested in issue #14:

- **macOS**: install via `brew`
- **Windows**: install via `scoop`
- **Linux** (and from source): install via `cargo`

## Changes

- Replaced the generic `install.sh` curl command with platform-specific instructions
- Added Homebrew, Scoop, and Cargo installation options
- Kept the existing `cargo install` for Linux/source

## Acceptance Criteria

- [x] README.md includes macOS installation via brew
- [x] README.md includes Windows installation via scoop
- [x] README.md includes Linux installation via cargo
- [x] Does not modify `install.sh` (removed from documentation, not from repo)
- [x] PR is single-purpose (only this issue)

Closes #14
