### PR TITLE
chore: enforce unreachable_pub and missing_docs, generalize DaemonServer

### DIFF
--- a/src/cli/command/blob.rs
+++ b/src/cli/command/blob.rs
@@ -6,7 +6,7 @@ use crate::daemon::protocol::Op;
 
 use super::BlobCmd;
 
-pub async fn run_import(
+pub(crate) async fn run_import(
     path: PathBuf,
     rings: Vec<String>,
     open: bool,
@@ -17,7 +17,7 @@ pub async fn run_import(
         .await
 }
 
-pub async fn run(cmd: BlobCmd, data_dir: &Path) -> Result<()> {
+pub(crate) async fn run(cmd: BlobCmd, data_dir: &Path) -> Result<()> {
     let client = super::daemon_client(data_dir)?;
     match cmd {
         BlobCmd::Import { path, rings, open } => client.run(Op::Import { path, rings, open }).await,

--- a/src/cli/command/daemon.rs
+++ b/src/cli/command/daemon.rs
@@ -11,7 +11,7 @@ use crate::daemon::protocol::{EventKind, Op};
 use crate::daemon::server::DaemonServer;
 use iroh_rings::RedbRegistry;
 
-pub async fn run_start(data_dir: &Path) -> Result<()> {
+pub(crate) async fn run_start(data_dir: &Path) -> Result<()> {
     let client = super::daemon_client(data_dir)?;
 
     if client.is_running().await {
@@ -67,7 +67,7 @@ pub async fn run_start(data_dir: &Path) -> Result<()> {
     anyhow::bail!("Rdrop daemon did not become reachable within 3s — check logs")
 }
 
-pub async fn run_stop(data_dir: &Path) -> Result<()> {
+pub(crate) async fn run_stop(data_dir: &Path) -> Result<()> {
     let client = super::daemon_client(data_dir)?;
 
     if !client.is_running().await {
@@ -88,7 +88,7 @@ pub async fn run_stop(data_dir: &Path) -> Result<()> {
     anyhow::bail!("Rdrop daemon did not stop within 3s")
 }
 
-pub async fn run_status(data_dir: &Path) -> Result<()> {
+pub(crate) async fn run_status(data_dir: &Path) -> Result<()> {
     let client = super::daemon_client(data_dir)?;
 
     if !client.is_running().await {
@@ -103,7 +103,7 @@ pub async fn run_status(data_dir: &Path) -> Result<()> {
     Ok(())
 }
 
-pub async fn run_serve(data_dir: &Path) -> Result<()> {
+pub(crate) async fn run_serve(data_dir: &Path) -> Result<()> {
     let cfg = Config::load_or_create(data_dir).context("loading config")?;
     let port = cfg.daemon_port;
     let registry =

--- a/src/cli/command/id.rs
+++ b/src/cli/command/id.rs
@@ -4,6 +4,6 @@ use anyhow::Result;
 
 use crate::daemon::protocol::Op;
 
-pub async fn run(data_dir: &Path) -> Result<()> {
+pub(crate) async fn run(data_dir: &Path) -> Result<()> {
     super::daemon_client(data_dir)?.run(Op::NodeId).await
 }

--- a/src/cli/command/mod.rs
+++ b/src/cli/command/mod.rs
@@ -11,15 +11,15 @@ pub(crate) fn daemon_client(data_dir: &Path) -> Result<DaemonClient> {
     Ok(DaemonClient::new(port))
 }
 
-pub mod blob;
-pub mod daemon;
-pub mod id;
-pub mod receive;
-pub mod ring;
-pub mod tag;
+pub(super) mod blob;
+pub(super) mod daemon;
+pub(super) mod id;
+pub(super) mod receive;
+pub(super) mod ring;
+pub(super) mod tag;
 
 #[derive(Subcommand)]
-pub enum Cmd {
+pub(super) enum Cmd {
     /// Manage rings
     #[command(subcommand)]
     Ring(RingCmd),
@@ -86,7 +86,7 @@ pub enum Cmd {
 }
 
 #[derive(Subcommand)]
-pub enum DaemonCmd {
+pub(super) enum DaemonCmd {
     /// Start the daemon in the background
     Start,
     /// Stop a running daemon
@@ -99,7 +99,7 @@ pub enum DaemonCmd {
 }
 
 #[derive(Subcommand)]
-pub enum BlobCmd {
+pub(super) enum BlobCmd {
     /// Import a file or directory into the blob store and print a ticket
     Import {
         /// Path to import (file or directory)
@@ -125,7 +125,7 @@ pub enum BlobCmd {
 }
 
 #[derive(Subcommand)]
-pub enum RingCmd {
+pub(super) enum RingCmd {
     /// Create a new ring with the given name
     New {
         /// Name for the ring (e.g. "friends", "work-team")

--- a/src/cli/command/receive.rs
+++ b/src/cli/command/receive.rs
@@ -6,7 +6,7 @@ use indicatif::{ProgressBar, ProgressStyle};
 use crate::core::ShareTicket;
 use crate::daemon::protocol::{EventKind, Op};
 
-pub fn check_dest(
+pub(crate) fn check_dest(
     dest: &Path,
     name: Option<&str>,
     hash_hex: &str,
@@ -27,7 +27,7 @@ pub fn check_dest(
     Ok(expected)
 }
 
-pub async fn run(
+pub(crate) async fn run(
     ticket_str: &str,
     dest: PathBuf,
     force_overwrite: bool,

--- a/src/cli/command/ring.rs
+++ b/src/cli/command/ring.rs
@@ -6,7 +6,7 @@ use crate::daemon::protocol::Op;
 
 use super::RingCmd;
 
-pub async fn run(cmd: RingCmd, data_dir: &Path) -> Result<()> {
+pub(crate) async fn run(cmd: RingCmd, data_dir: &Path) -> Result<()> {
     let client = super::daemon_client(data_dir)?;
     let op = match cmd {
         RingCmd::New { name } => Op::RingNew { name },

--- a/src/cli/command/tag.rs
+++ b/src/cli/command/tag.rs
@@ -4,7 +4,7 @@ use anyhow::Result;
 
 use crate::daemon::protocol::Op;
 
-pub async fn run_tag(
+pub(crate) async fn run_tag(
     target: String,
     rings: Vec<String>,
     open: bool,
@@ -19,7 +19,7 @@ pub async fn run_tag(
         .await
 }
 
-pub async fn run_tags(target: String, data_dir: &Path) -> Result<()> {
+pub(crate) async fn run_tags(target: String, data_dir: &Path) -> Result<()> {
     super::daemon_client(data_dir)?
         .run(Op::Tags { target })
         .await

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -64,6 +64,12 @@ struct Cli {
     command: Cmd,
 }
 
+/// Parse CLI arguments and dispatch the requested command to the daemon.
+///
+/// # Errors
+///
+/// Returns an error if the command fails (connection refused, daemon not
+/// running, invalid arguments, etc.).
 pub async fn run() -> Result<()> {
     let cli = Cli::parse();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -15,7 +15,11 @@ use serde::{Deserialize, Serialize};
 /// [`EndpointId`]: iroh::EndpointId
 #[derive(Debug, Serialize, Deserialize)]
 pub struct Config {
+    /// Long-term Ed25519 secret key; determines the [`EndpointId`] peers add to their rings.
+    ///
+    /// [`EndpointId`]: iroh::EndpointId
     pub secret_key: SecretKey,
+    /// TCP port the daemon listens on for local IPC connections (default: 60001).
     #[serde(default = "Config::default_daemon_port")]
     pub daemon_port: u16,
 }

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -40,8 +40,11 @@ use iroh_rings::Registry;
 /// [`Node::shutdown`] so the blob store is flushed to disk before the process
 /// exits.
 pub struct Node<R> {
+    /// The iroh QUIC endpoint — manages connections, NAT traversal, and relay fallback.
     pub endpoint: Endpoint,
+    /// The iroh-blobs persistent store — holds all locally imported and received blobs.
     pub store: FsStore,
+    /// The ring registry — tracks ring membership and per-blob access tags.
     pub registry: R,
     router: Router,
 }
@@ -111,7 +114,7 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
     /// Import a single file into the blob store.
     ///
     /// The file is chunked, BLAKE3-hashed, and pinned with a named tag (the
-    /// filename). Returns the root hash and `BlobFormat::Raw`.
+    /// leaf filename, i.e. `path.file_name()`). Returns the root hash and `BlobFormat::Raw`.
     ///
     /// # Errors
     ///
@@ -222,8 +225,9 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
 
     /// Remove a blob from the local store by deleting its named tags.
     ///
-    /// Ring tags in the registry must be removed separately. Disk space is
-    /// reclaimed on the next GC cycle (every 30 s while the node is running).
+    /// Ring tags in the registry must be removed separately by the caller
+    /// before invoking this method. Disk space is reclaimed on the next GC
+    /// cycle (every 30 s while the node is running).
     ///
     /// # Errors
     ///

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -22,6 +22,8 @@ use tracing::info;
 pub(crate) use iroh_rings::protocol::{encode_request, RingGate, Status, SC_ALPN};
 pub(crate) use iroh_rings::transfers::fs::encode_ranges_wire;
 
+// export_bao emits an 8-byte little-endian content size before the bao tree,
+// so the receiver knows the total before any leaf data arrives.
 const BAO_SIZE_HEADER: usize = size_of::<u64>();
 
 pub(crate) struct RingReceiver {

--- a/src/core/ticket.rs
+++ b/src/core/ticket.rs
@@ -23,6 +23,7 @@ pub struct ShareTicket {
     addr: EndpointAddr,
     hash: Hash,
     format: BlobFormat,
+    /// Human-readable display name, typically the original filename; `None` when unknown.
     pub name: Option<String>,
 }
 

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -1,3 +1,7 @@
+//! Lightweight TCP client for sending IPC operations to a running [`DaemonServer`].
+//!
+//! [`DaemonServer`]: crate::daemon::server::DaemonServer
+
 use std::net::SocketAddr;
 
 use anyhow::{Context, Result};
@@ -82,8 +86,9 @@ impl DaemonClient {
         Ok(())
     }
 
-    /// Convenience wrapper: prints [`EventKind::Line`] events to stdout and
-    /// converts [`EventKind::Error`] into an `anyhow` error.
+    /// Convenience wrapper: prints [`EventKind::Line`] events to stdout,
+    /// converts [`EventKind::Error`] into an `anyhow` error, and silently
+    /// discards [`EventKind::Progress`] events.
     pub async fn run(&self, op: Op) -> Result<()> {
         let mut err: Option<String> = None;
         self.send(op, |event| match event.kind {

--- a/src/daemon/mod.rs
+++ b/src/daemon/mod.rs
@@ -12,6 +12,6 @@ pub mod client;
 pub mod protocol;
 pub mod server;
 
-/// Maximum byte length of a single IPC request or response line
-/// in the wire protocol.
+// 512 KiB covers any realistic JSON request (long --data-dir paths, many
+// --ring flags, long ticket URIs) while still bounding per-connection memory.
 pub(crate) const MAX_LINE_BYTES: usize = 512 * 1024;

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -1,3 +1,5 @@
+//! IPC protocol types: [`Request`], [`Op`], [`Event`], and [`EventKind`].
+
 use std::path::PathBuf;
 
 use serde::{Deserialize, Serialize};
@@ -14,7 +16,9 @@ use uuid::Uuid;
 /// files simultaneously).
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Request {
+    /// Unique identifier echoed on every response event for this request.
     pub req_id: Uuid,
+    /// The operation to perform.
     #[serde(flatten)]
     pub op: Op,
 }
@@ -31,40 +35,75 @@ pub enum Op {
     NodeId,
     /// Import a file or directory and tag it with the given rings.
     Import {
+        /// Path to the file or directory to import.
         path: PathBuf,
+        /// Ring names to tag the blob with (ignored when `open` is `true`).
         rings: Vec<String>,
+        /// Tag the blob as publicly accessible, overriding `rings`.
         open: bool,
     },
     /// List all blobs in the local store.
     BlobList,
     /// Remove a blob from the local store. `target` is a filename or hex hash.
-    BlobRemove { target: String },
+    BlobRemove {
+        /// File path or BLAKE3 hex hash identifying the blob to remove.
+        target: String,
+    },
     /// Tag a blob with the given rings (or the open ring). `target` is a filename or hex hash.
     Tag {
+        /// File path or BLAKE3 hex hash identifying the blob to tag.
         target: String,
+        /// Ring names to apply (ignored when `open` is `true`).
         rings: Vec<String>,
+        /// Tag the blob as publicly accessible, overriding `rings`.
         open: bool,
     },
     /// List the rings a blob is tagged with. `target` is a filename or hex hash.
-    Tags { target: String },
+    Tags {
+        /// File path or BLAKE3 hex hash identifying the blob to inspect.
+        target: String,
+    },
     /// Create a new ring with the given name.
-    RingNew { name: String },
+    RingNew {
+        /// Name for the new ring (e.g. `"friends"` or `"work-team"`).
+        name: String,
+    },
     /// List all rings.
     RingList,
     /// Add `peer` to `ring`, optionally under a human-readable `nickname`.
     RingAdd {
+        /// Name of the ring to add the peer to.
         ring: String,
+        /// Base32 [`EndpointId`] string of the peer to add.
+        ///
+        /// [`EndpointId`]: iroh::EndpointId
         peer: String,
+        /// Optional human-readable label for this peer.
         nickname: Option<String>,
     },
     /// Remove `peer` from `ring`.
-    RingRemove { ring: String, peer: String },
+    RingRemove {
+        /// Name of the ring to remove the peer from.
+        ring: String,
+        /// Base32 [`EndpointId`] string of the peer to remove.
+        ///
+        /// [`EndpointId`]: iroh::EndpointId
+        peer: String,
+    },
     /// List all members of `ring`.
-    RingMembers { ring: String },
+    RingMembers {
+        /// Name of the ring whose membership to list.
+        ring: String,
+    },
     /// Download the blob described by `ticket` and export it to `dest`.
     Receive {
+        /// URI-encoded [`ShareTicket`] produced by `rdrop import` or `rdrop blob list`.
+        ///
+        /// [`ShareTicket`]: crate::core::ShareTicket
         ticket: String,
+        /// Filesystem path to write the received file or directory to.
         dest: PathBuf,
+        /// Overwrite an existing destination without prompting.
         force_overwrite: bool,
     },
     /// Gracefully stop the daemon after draining in-flight requests.
@@ -78,22 +117,36 @@ pub enum Op {
 /// sent in the originating [`Request`], enabling multiplexed connections.
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 pub struct Event {
+    /// Matches the [`Request::req_id`] that triggered this event.
     pub req_id: Uuid,
+    /// The event payload.
     #[serde(flatten)]
     pub kind: EventKind,
 }
 
+/// The payload of a daemon [`Event`].
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum EventKind {
     /// Line of text to be printed to stdout (by a console process) or rendered (by a GUI).
-    Line { text: String },
+    Line {
+        /// The line of text to display.
+        text: String,
+    },
     /// Download/upload progress indicator for long-running transfers.
-    Progress { done: u64, total: u64 },
+    Progress {
+        /// Bytes received or sent so far.
+        done: u64,
+        /// Total expected bytes.
+        total: u64,
+    },
     /// Signal of request completed successfully; no further events will follow for this req_id.
     Done,
     /// Signal of request failed; no further events will follow for this req_id.
-    Error { message: String },
+    Error {
+        /// Human-readable description of the failure.
+        message: String,
+    },
 }
 
 impl Event {

--- a/src/daemon/server/handlers/blob.rs
+++ b/src/daemon/server/handlers/blob.rs
@@ -1,19 +1,18 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use iroh_rings::{RedbRegistry, Registry, OPEN_RING_NAME};
+use iroh_rings::{Registry, OPEN_RING_NAME};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::core::Node;
 use crate::daemon::protocol::Event;
-use crate::util::parse_hash;
 
-use super::send;
+use super::{resolve_target, send};
 
-pub async fn handle_import(
+pub(crate) async fn handle_import<R: Registry + Clone + Send + Sync + 'static>(
     req_id: Uuid,
-    node: &Node<RedbRegistry>,
+    node: &Node<R>,
     tx: &mpsc::Sender<Event>,
     path: PathBuf,
     rings: Vec<String>,
@@ -101,9 +100,9 @@ pub async fn handle_import(
     Ok(())
 }
 
-pub async fn handle_blob_list(
+pub(crate) async fn handle_blob_list<R: Registry + Clone + Send + Sync + 'static>(
     req_id: Uuid,
-    node: &Node<RedbRegistry>,
+    node: &Node<R>,
     tx: &mpsc::Sender<Event>,
 ) -> Result<()> {
     let blobs = node.list_blobs().await?;
@@ -137,19 +136,13 @@ pub async fn handle_blob_list(
     Ok(())
 }
 
-pub async fn handle_blob_remove(
+pub(crate) async fn handle_blob_remove<R: Registry + Clone + Send + Sync + 'static>(
     req_id: Uuid,
-    node: &Node<RedbRegistry>,
+    node: &Node<R>,
     tx: &mpsc::Sender<Event>,
     target: String,
 ) -> Result<()> {
-    let path = PathBuf::from(&target);
-    let hash = if path.exists() {
-        let (hash, _) = node.import_path(&path).await?;
-        hash
-    } else {
-        parse_hash(&target)?
-    };
+    let hash = resolve_target(node, &target).await?;
     node.registry.remove_ring_from_resource(*hash.as_bytes())?;
     node.delete_blob(hash).await?;
     send(tx, Event::line(req_id, format!("Removed {hash}"))).await;

--- a/src/daemon/server/handlers/mod.rs
+++ b/src/daemon/server/handlers/mod.rs
@@ -3,10 +3,30 @@ pub(super) mod receive;
 pub(super) mod ring;
 pub(super) mod tag;
 
+use std::path::PathBuf;
+
+use anyhow::Result;
+use iroh_blobs::Hash;
+use iroh_rings::Registry;
 use tokio::sync::mpsc;
 
+use crate::core::Node;
 use crate::daemon::protocol::Event;
+use crate::util::parse_hash;
 
 pub(super) async fn send(tx: &mpsc::Sender<Event>, event: Event) {
     let _ = tx.send(event).await;
+}
+
+pub(super) async fn resolve_target<R: Registry + Clone + Send + Sync + 'static>(
+    node: &Node<R>,
+    target: &str,
+) -> Result<Hash> {
+    let path = PathBuf::from(target);
+    if path.exists() {
+        let (hash, _) = node.import_path(&path).await?;
+        Ok(hash)
+    } else {
+        parse_hash(target)
+    }
 }

--- a/src/daemon/server/handlers/receive.rs
+++ b/src/daemon/server/handlers/receive.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use iroh_rings::RedbRegistry;
+use iroh_rings::Registry;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -10,9 +10,9 @@ use crate::daemon::protocol::Event;
 
 use super::send;
 
-pub async fn handle_receive(
+pub(crate) async fn handle_receive<R: Registry + Clone + Send + Sync + 'static>(
     req_id: Uuid,
-    node: &Node<RedbRegistry>,
+    node: &Node<R>,
     tx: &mpsc::Sender<Event>,
     ticket_str: String,
     dest: PathBuf,

--- a/src/daemon/server/handlers/ring.rs
+++ b/src/daemon/server/handlers/ring.rs
@@ -3,7 +3,7 @@ use iroh_rings::{Registry, OPEN_RING_NAME};
 
 use crate::util::parse_peer_id;
 
-pub fn ring_new_lines(registry: &impl Registry, name: &str) -> Result<Vec<String>> {
+pub(crate) fn ring_new_lines(registry: &impl Registry, name: &str) -> Result<Vec<String>> {
     registry.create_ring(name)?;
     Ok(vec![
         format!("Ring created: {name}"),
@@ -11,7 +11,7 @@ pub fn ring_new_lines(registry: &impl Registry, name: &str) -> Result<Vec<String
     ])
 }
 
-pub fn ring_list_lines(registry: &impl Registry) -> Result<Vec<String>> {
+pub(crate) fn ring_list_lines(registry: &impl Registry) -> Result<Vec<String>> {
     let rings = registry.list_rings()?;
     let mut out = vec![format!("{} rings:", rings.len())];
     for r in rings {
@@ -28,7 +28,7 @@ pub fn ring_list_lines(registry: &impl Registry) -> Result<Vec<String>> {
     Ok(out)
 }
 
-pub fn ring_add_lines(
+pub(crate) fn ring_add_lines(
     registry: &impl Registry,
     public_id: iroh::EndpointId,
     ring: &str,
@@ -52,7 +52,11 @@ pub fn ring_add_lines(
     Ok(vec![line])
 }
 
-pub fn ring_remove_lines(registry: &impl Registry, ring: &str, peer: &str) -> Result<Vec<String>> {
+pub(crate) fn ring_remove_lines(
+    registry: &impl Registry,
+    ring: &str,
+    peer: &str,
+) -> Result<Vec<String>> {
     if ring == OPEN_RING_NAME {
         return Ok(vec![
             "The open ring has no membership list to remove from.".to_owned()
@@ -63,7 +67,7 @@ pub fn ring_remove_lines(registry: &impl Registry, ring: &str, peer: &str) -> Re
     Ok(vec![format!("Removed {peer_id} from ring {ring}")])
 }
 
-pub fn ring_members_lines(registry: &impl Registry, ring: &str) -> Result<Vec<String>> {
+pub(crate) fn ring_members_lines(registry: &impl Registry, ring: &str) -> Result<Vec<String>> {
     if ring == OPEN_RING_NAME {
         return Ok(vec![
             "The open ring is public — any peer may access blobs tagged with it.".to_owned(),

--- a/src/daemon/server/handlers/tag.rs
+++ b/src/daemon/server/handlers/tag.rs
@@ -1,19 +1,16 @@
-use std::path::PathBuf;
-
 use anyhow::Result;
-use iroh_rings::{RedbRegistry, Registry, OPEN_RING_NAME};
+use iroh_rings::{Registry, OPEN_RING_NAME};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
 use crate::core::Node;
 use crate::daemon::protocol::Event;
-use crate::util::parse_hash;
 
-use super::send;
+use super::{resolve_target, send};
 
-pub async fn handle_tag(
+pub(crate) async fn handle_tag<R: Registry + Clone + Send + Sync + 'static>(
     req_id: Uuid,
-    node: &Node<RedbRegistry>,
+    node: &Node<R>,
     tx: &mpsc::Sender<Event>,
     target: String,
     rings: Vec<String>,
@@ -27,13 +24,7 @@ pub async fn handle_tag(
         );
     }
 
-    let path = PathBuf::from(&target);
-    let hash = if path.exists() {
-        let (hash, _) = node.import_path(&path).await?;
-        hash
-    } else {
-        parse_hash(&target)?
-    };
+    let hash = resolve_target(node, &target).await?;
     for ring in &rings {
         node.registry.add_ring_to_resource(*hash.as_bytes(), ring)?;
         send(
@@ -58,19 +49,13 @@ pub async fn handle_tag(
     Ok(())
 }
 
-pub async fn handle_tags(
+pub(crate) async fn handle_tags<R: Registry + Clone + Send + Sync + 'static>(
     req_id: Uuid,
-    node: &Node<RedbRegistry>,
+    node: &Node<R>,
     tx: &mpsc::Sender<Event>,
     target: String,
 ) -> Result<()> {
-    let path = PathBuf::from(&target);
-    let hash = if path.exists() {
-        let (hash, _) = node.import_path(&path).await?;
-        hash
-    } else {
-        parse_hash(&target)?
-    };
+    let hash = resolve_target(node, &target).await?;
     let rings = node.registry.list_resource_rings(*hash.as_bytes())?;
     if rings.is_empty() {
         send(

--- a/src/daemon/server/mod.rs
+++ b/src/daemon/server/mod.rs
@@ -16,6 +16,7 @@ use std::time::Duration;
 
 use anyhow::Result;
 use futures_lite::StreamExt;
+use iroh_rings::Registry;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, Notify};
@@ -26,7 +27,6 @@ use uuid::Uuid;
 
 use crate::core::Node;
 use crate::daemon::protocol::{Event, Op, Request};
-use iroh_rings::RedbRegistry;
 
 /// The background daemon server.
 ///
@@ -38,19 +38,19 @@ use iroh_rings::RedbRegistry;
 /// [`Op`]: crate::daemon::protocol::Op
 /// [`DaemonClient`]: crate::daemon::client::DaemonClient
 /// [`Op::Shutdown`]: crate::daemon::protocol::Op::Shutdown
-pub struct DaemonServer {
-    node: Arc<Node<RedbRegistry>>,
+pub struct DaemonServer<R> {
+    node: Arc<Node<R>>,
     listener: TcpListener,
     shutdown: Arc<Notify>,
 }
 
-impl DaemonServer {
+impl<R: Registry + Clone + Send + Sync + 'static> DaemonServer<R> {
     /// Bind the daemon to `127.0.0.1:port` (use `0` to let the OS pick a port).
     ///
     /// # Errors
     ///
     /// Returns an error if the port is already in use.
-    pub async fn bind(node: Node<RedbRegistry>, port: u16) -> Result<Self> {
+    pub async fn bind(node: Node<R>, port: u16) -> Result<Self> {
         let listener = TcpListener::bind(("127.0.0.1", port))
             .await
             .map_err(|e| anyhow::anyhow!("cannot bind to port {port}: {e}"))?;
@@ -64,9 +64,12 @@ impl DaemonServer {
 
     /// Returns the port the server is actually listening on.
     ///
-    /// Useful when the server was bound on port `0`.
+    /// Useful when bound on port `0` (OS-assigned ephemeral port).
     pub fn local_port(&self) -> u16 {
-        self.listener.local_addr().unwrap().port()
+        self.listener
+            .local_addr()
+            .expect("listener is bound")
+            .port()
     }
 
     /// Run the server event loop until an [`Op::Shutdown`] request is received.
@@ -121,9 +124,9 @@ impl DaemonServer {
 
 use super::MAX_LINE_BYTES;
 
-async fn handle_connection(
+async fn handle_connection<R: Registry + Clone + Send + Sync + 'static>(
     stream: TcpStream,
-    node: Arc<Node<RedbRegistry>>,
+    node: Arc<Node<R>>,
     shutdown: Arc<Notify>,
 ) -> Result<()> {
     let (reader, mut writer) = stream.into_split();
@@ -189,10 +192,10 @@ async fn emit(writer: &mut (impl AsyncWriteExt + Unpin), event: &Event) -> bool 
         .is_ok()
 }
 
-async fn dispatch(
+async fn dispatch<R: Registry + Clone + Send + Sync + 'static>(
     op: Op,
     req_id: Uuid,
-    node: Arc<Node<RedbRegistry>>,
+    node: Arc<Node<R>>,
     tx: mpsc::Sender<Event>,
     shutdown: Arc<Notify>,
 ) {
@@ -210,10 +213,10 @@ async fn dispatch(
     }
 }
 
-async fn handle_op(
+async fn handle_op<R: Registry + Clone + Send + Sync + 'static>(
     op: Op,
     req_id: Uuid,
-    node: &Node<RedbRegistry>,
+    node: &Node<R>,
     tx: &mpsc::Sender<Event>,
 ) -> Result<()> {
     match op {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![deny(elided_lifetimes_in_paths)]
+#![deny(unreachable_pub)]
+#![warn(missing_docs)]
+
 //! # ringdrop
 //!
 //! P2P file transfer with ring-based access control, built on [iroh] (QUIC +


### PR DESCRIPTION
Closes #23

- Add `#![deny(unreachable_pub)]` and `#![warn(missing_docs)]` lint gates;
- Change visibility (from `pub` to `pub(super)`/`pub(crate)` on many items;
- Add field docs on `Config`, `Node`, `ShareTicket`, `Request`, `Event`, `Op`, `EventKind`;
- Add `//!` module docs to daemon/client and daemon/protocol;
- Add explaination comments to `MAX_LINE_BYTES` and `BAO_SIZE_HEADER`;
- Parameterize `DaemonServer<R>` over the registry type so the server layer can be tested with an in-memory `Registry` without a redb file on disk.
