### PR TITLE
Add --ring and --peer filters on blob list command

### DIFF
--- a/src/cli/command/blob.rs
+++ b/src/cli/command/blob.rs
@@ -22,6 +22,13 @@ pub(crate) async fn run(cmd: BlobCmd, data_dir: &Path) -> Result<()> {
     match cmd {
         BlobCmd::Import { path, rings, open } => client.run(Op::Import { path, rings, open }).await,
         BlobCmd::Remove { target } => client.run(Op::BlobRemove { target }).await,
-        BlobCmd::List => client.run(Op::BlobList).await,
+        BlobCmd::List => {
+            client
+                .run(Op::BlobList {
+                    peer: None,
+                    rings: None,
+                })
+                .await
+        }
     }
 }

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -7,6 +7,7 @@
 //!  - a `Registry`              — ring membership and file tagging
 
 use std::{
+    collections::HashSet,
     path::{Path, PathBuf},
     sync::Arc,
     time::Duration,
@@ -29,6 +30,9 @@ use super::ticket::ShareTicket;
 use crate::config::Config;
 use iroh_rings::FsTransfer;
 use iroh_rings::Registry;
+use iroh_rings::OPEN_RING_NAME;
+
+use crate::util::parse_peer_id;
 
 /// A ringdrop P2P node.
 ///
@@ -47,6 +51,35 @@ pub struct Node<R> {
     /// The ring registry — tracks ring membership and per-blob access tags.
     pub registry: R,
     router: Router,
+}
+
+/// Returns the set of ring names accessible to `peer`: all rings the peer
+/// belongs to, plus the built-in open ring (which is accessible to everyone).
+///
+/// # Errors
+///
+/// Returns an error if `peer` is not a valid [`EndpointId`] encoding or if a
+/// registry lookup fails.
+///
+/// [`EndpointId`]: iroh::EndpointId
+fn peer_ring_set<R: Registry>(registry: &R, peer: &str) -> Result<HashSet<String>> {
+    let peer_id = parse_peer_id(peer)?;
+    let mut set: HashSet<String> = registry
+        .list_rings()?
+        .into_iter()
+        .filter(|r| !r.is_open())
+        .filter(|r| {
+            registry
+                .list_ring_peers(r.as_str())
+                .unwrap_or_default()
+                .iter()
+                .any(|(id, _)| *id == peer_id)
+        })
+        .map(|r| r.as_str().to_owned())
+        .collect();
+    // open ring is accessible to every peer
+    set.insert(OPEN_RING_NAME.to_owned());
+    Ok(set)
 }
 
 impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
@@ -207,12 +240,25 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
         Ok((hash, format))
     }
 
-    /// List all blobs in the local store as `(hash, format, tag_name)` triples.
+    /// List blobs in the local store as `(hash, format, tag_name)` triples.
+    ///
+    /// When `peer` is supplied only blobs accessible to that peer are returned
+    /// (i.e. the blob is tagged with at least one ring the peer belongs to).
+    /// When `rings` is supplied only blobs tagged with at least one of those
+    /// ring names are returned (OR semantics).  When both are given the
+    /// filters are combined: a blob must satisfy both independently.
     ///
     /// # Errors
     ///
-    /// Returns an error if the tag store cannot be read.
-    pub async fn list_blobs(&self) -> Result<Vec<(Hash, BlobFormat, String)>> {
+    /// Returns an error if the tag store cannot be read, if `peer` is not a
+    /// valid [`EndpointId`] encoding, or if a registry lookup fails.
+    ///
+    /// [`EndpointId`]: iroh::EndpointId
+    pub async fn list_blobs(
+        &self,
+        peer: Option<String>,
+        rings: Option<Vec<String>>,
+    ) -> Result<Vec<(Hash, BlobFormat, String)>> {
         let mut stream = self.store.tags().list().await?;
         let mut blobs = Vec::new();
         while let Some(item) = stream.next().await {
@@ -220,6 +266,32 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
             let name = String::from_utf8_lossy(&info.name.0).into_owned();
             blobs.push((info.hash, info.format, name));
         }
+
+        let peer_rings: Option<HashSet<String>> = peer
+            .as_deref()
+            .map(|s| peer_ring_set(&self.registry, s))
+            .transpose()?;
+        let ring_names: Option<HashSet<String>> = rings.map(|rs| rs.into_iter().collect());
+
+        if peer_rings.is_some() || ring_names.is_some() {
+            let mut filtered = Vec::with_capacity(blobs.len());
+            for (hash, format, name) in blobs {
+                let blob_rings = self.registry.list_resource_rings(*hash.as_bytes())?;
+                if let Some(ref rset) = ring_names {
+                    if !blob_rings.iter().any(|r| rset.contains(r.as_str())) {
+                        continue;
+                    }
+                }
+                if let Some(ref pset) = peer_rings {
+                    if !blob_rings.iter().any(|r| pset.contains(r.as_str())) {
+                        continue;
+                    }
+                }
+                filtered.push((hash, format, name));
+            }
+            blobs = filtered;
+        }
+
         Ok(blobs)
     }
 
@@ -389,5 +461,52 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
             .await
             .context("flushing blob store to disk")?;
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use iroh::SecretKey;
+    use iroh_rings::{InMemoryRegistry, OPEN_RING_NAME};
+
+    use super::*;
+
+    fn make_registry() -> InMemoryRegistry {
+        InMemoryRegistry::default()
+    }
+
+    fn make_peer_str() -> (iroh::EndpointId, String) {
+        let id = SecretKey::generate().public();
+        let s = id.to_string();
+        (id, s)
+    }
+
+    #[test]
+    fn peer_ring_set_includes_explicit_rings_and_open() {
+        let reg = make_registry();
+        reg.create_ring("friends").unwrap();
+        reg.create_ring("work").unwrap();
+        let (peer_id, peer_str) = make_peer_str();
+        reg.add_peer_to_ring("friends", peer_id, None).unwrap();
+
+        let set = peer_ring_set(&reg, &peer_str).unwrap();
+        assert!(set.contains("friends"));
+        assert!(set.contains(OPEN_RING_NAME));
+        assert!(!set.contains("work"));
+    }
+
+    #[test]
+    fn peer_ring_set_always_includes_open_even_with_no_memberships() {
+        let reg = make_registry();
+        let (_, peer_str) = make_peer_str();
+
+        let set = peer_ring_set(&reg, &peer_str).unwrap();
+        assert_eq!(set, std::iter::once(OPEN_RING_NAME.to_owned()).collect());
+    }
+
+    #[test]
+    fn peer_ring_set_rejects_invalid_peer_string() {
+        let reg = make_registry();
+        assert!(peer_ring_set(&reg, "not-a-valid-peer-id").is_err());
     }
 }

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -43,7 +43,12 @@ pub enum Op {
         open: bool,
     },
     /// List all blobs in the local store.
-    BlobList,
+    BlobList {
+        /// Optional filter by this peer-id.
+        peer: Option<String>,
+        /// Optional filter by a ring name.
+        rings: Option<Vec<String>>,
+    },
     /// Remove a blob from the local store. `target` is a filename or hex hash.
     BlobRemove {
         /// File path or BLAKE3 hex hash identifying the blob to remove.
@@ -200,8 +205,12 @@ mod tests {
     #[test]
     fn op_blob_list_serializes_correctly() {
         assert_eq!(
-            serde_json::to_string(&Op::BlobList).unwrap(),
-            r#"{"op":"blob_list"}"#
+            serde_json::to_string(&Op::BlobList {
+                peer: None,
+                rings: None,
+            })
+            .unwrap(),
+            r#"{"op":"blob_list","peer":null,"rings":null}"#
         );
     }
 
@@ -214,18 +223,21 @@ mod tests {
         assert_eq!(json, r#"{"op":"ring_new","name":"friends"}"#);
     }
 
-    // ── Request: req_id is mandatory ─────────────────────────────────────────
+    // Request: req_id is mandatory
 
     #[test]
     fn request_serializes_req_id() {
         let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
         let req = Request {
             req_id: id,
-            op: Op::BlobList,
+            op: Op::BlobList {
+                peer: None,
+                rings: None,
+            },
         };
         assert_eq!(
             serde_json::to_string(&req).unwrap(),
-            r#"{"req_id":"550e8400-e29b-41d4-a716-446655440000","op":"blob_list"}"#
+            r#"{"req_id":"550e8400-e29b-41d4-a716-446655440000","op":"blob_list","peer":null,"rings":null}"#
         );
     }
 
@@ -248,7 +260,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ── Event: req_id is mandatory ────────────────────────────────────────────
+    // Event: req_id is mandatory
 
     #[test]
     fn event_done_serializes_req_id_and_type() {
@@ -292,7 +304,7 @@ mod tests {
         assert!(result.is_err());
     }
 
-    // ── Round-trips ───────────────────────────────────────────────────────────
+    // Round-trips
 
     #[test]
     fn request_round_trips_through_json() {

--- a/src/daemon/server/handlers/blob.rs
+++ b/src/daemon/server/handlers/blob.rs
@@ -93,10 +93,21 @@ pub(crate) async fn handle_blob_list<R: Registry + Clone + Send + Sync + 'static
     req_id: Uuid,
     node: &Node<R>,
     tx: &mpsc::Sender<Event>,
+    peer: Option<String>,
+    rings: Option<Vec<String>>,
 ) -> Result<()> {
-    let blobs = node.list_blobs().await?;
+    let blobs = node.list_blobs(peer.clone(), rings).await?;
     if blobs.is_empty() {
-        send(tx, Event::line(req_id, "No blobs in local store.")).await;
+        let peer_str = if let Some(peer) = peer {
+            format!(" accessible by peer {}", peer)
+        } else {
+            String::from("")
+        };
+        send(
+            tx,
+            Event::line(req_id, format!("No blobs in local store{}.", peer_str)),
+        )
+        .await;
     } else {
         send(tx, Event::line(req_id, format!("{} blobs:", blobs.len()))).await;
         for (hash, format, name) in blobs {

--- a/src/daemon/server/mod.rs
+++ b/src/daemon/server/mod.rs
@@ -229,8 +229,8 @@ async fn handle_op<R: Registry + Clone + Send + Sync + 'static>(
         Op::Import { path, rings, open } => {
             handlers::blob::handle_import(req_id, node, tx, path, rings, open).await?;
         }
-        Op::BlobList => {
-            handlers::blob::handle_blob_list(req_id, node, tx).await?;
+        Op::BlobList { peer, rings } => {
+            handlers::blob::handle_blob_list(req_id, node, tx, peer, rings).await?;
         }
         Op::BlobRemove { target } => {
             handlers::blob::handle_blob_remove(req_id, node, tx, target).await?;

--- a/tests/blob_management.rs
+++ b/tests/blob_management.rs
@@ -11,7 +11,7 @@ async fn import_file_preserves_filename_in_tag() {
 
     let (hash, _format) = node.node.import_file(&file).await.unwrap();
 
-    let blobs = node.node.list_blobs().await.unwrap();
+    let blobs = node.node.list_blobs(None, None).await.unwrap();
     let (_, _, name) = blobs.into_iter().find(|(h, _, _)| *h == hash).unwrap();
     assert_eq!(name, "report.pdf");
 
@@ -29,7 +29,7 @@ async fn import_directory_preserves_dir_name_in_tag() {
 
     let (hash, _format) = node.node.import_directory(&named_dir).await.unwrap();
 
-    let blobs = node.node.list_blobs().await.unwrap();
+    let blobs = node.node.list_blobs(None, None).await.unwrap();
     let (_, _, name) = blobs.into_iter().find(|(h, _, _)| *h == hash).unwrap();
     assert_eq!(name, "my_dataset");
 
@@ -43,10 +43,10 @@ async fn delete_blob_removes_filename_tagged_entry() {
     let file = common::write_file(src.path(), "to_delete.bin", b"delete me").await;
 
     let (hash, _format) = node.node.import_file(&file).await.unwrap();
-    assert_eq!(node.node.list_blobs().await.unwrap().len(), 1);
+    assert_eq!(node.node.list_blobs(None, None).await.unwrap().len(), 1);
 
     node.node.delete_blob(hash).await.unwrap();
-    assert!(node.node.list_blobs().await.unwrap().is_empty());
+    assert!(node.node.list_blobs(None, None).await.unwrap().is_empty());
 
     node.shutdown().await;
 }
@@ -61,7 +61,7 @@ async fn list_blobs_ticket_carries_original_filename() {
 
     let (_, fmt, name) = node
         .node
-        .list_blobs()
+        .list_blobs(None, None)
         .await
         .unwrap()
         .into_iter()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -116,11 +116,17 @@ pub async fn daemon_contract(daemon: TestDaemon) {
     let mut lines: Vec<String> = Vec::new();
     daemon
         .client
-        .send(Op::BlobList, |event| {
-            if let EventKind::Line { text } = event.kind {
-                lines.push(text);
-            }
-        })
+        .send(
+            Op::BlobList {
+                peer: None,
+                rings: None,
+            },
+            |event| {
+                if let EventKind::Line { text } = event.kind {
+                    lines.push(text);
+                }
+            },
+        )
         .await
         .unwrap();
     assert_eq!(lines, vec!["No blobs in local store."]);


### PR DESCRIPTION
Closes #27

The `blob list` command now supports the two optional and non mutually-excluded filters:

```sh
rdrop blob list --peer abc45f... --ring music
```

Behavior:
- when only --peer <peer-id> is given, all blobs for which the peer has access to are returned, including the blobs associated via the "open" ring;
- when only --ring <ring-name> is given, all blobs associated to those specific rings are returned (excluding the "open" ring if this is not specified in the filter list), independently of the peer (which is not specified in this case);
- when both --ring and --peer options are specified, blobs are filtered by both (excluding the "open" ring if this is not specified in the filter list);
- when neither --ring or --peer are specified, all blobs are be returned.

