### PR TITLE
Support iroh rings v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "iroh-rings"
 version = "0.4.0"
-source = "git+https://github.com/rikettsie/iroh-rings.git?branch=feat%2Fr-w-d-rebac-permission-model#a4362099edf4a5c2199524ebd3d51b5dd509a8e1"
+source = "git+https://github.com/rikettsie/iroh-rings.git?branch=feat%2Fr-w-d-rebac-permission-model#7c066ed3c1677ad6df5569049559bba5b7417d42"
 dependencies = [
  "anyhow",
  "bao-tree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1948,7 +1948,7 @@ dependencies = [
 [[package]]
 name = "iroh-rings"
 version = "0.4.0"
-source = "git+https://github.com/rikettsie/iroh-rings.git?branch=feat%2Fr-w-d-rebac-permission-model#b3065dda79d3c0946fb7621a308ad98e791b4eec"
+source = "git+https://github.com/rikettsie/iroh-rings.git?branch=feat%2Fr-w-d-rebac-permission-model#a4362099edf4a5c2199524ebd3d51b5dd509a8e1"
 dependencies = [
  "anyhow",
  "bao-tree",
@@ -2522,7 +2522,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3263,7 +3263,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3321,7 +3321,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3342,7 +3342,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3434,7 +3434,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3792,7 +3792,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4487,7 +4487,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1947,9 +1947,8 @@ dependencies = [
 
 [[package]]
 name = "iroh-rings"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b64b964368edeb1fea63ddb8741cce1b7c1f8f216af9e36ebdb0227cea6199c"
+version = "0.4.0"
+source = "git+https://github.com/rikettsie/iroh-rings.git?branch=feat%2Fr-w-d-rebac-permission-model#b3065dda79d3c0946fb7621a308ad98e791b4eec"
 dependencies = [
  "anyhow",
  "bao-tree",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1947,8 +1947,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-rings"
-version = "0.4.0"
-source = "git+https://github.com/rikettsie/iroh-rings.git?branch=feat%2Fr-w-d-rebac-permission-model#7c066ed3c1677ad6df5569049559bba5b7417d42"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "452307f2dff9166f44f9a9be08e780cbf7f6e7f2d4caed89ef91f3c4c419f6a2"
 dependencies = [
  "anyhow",
  "bao-tree",
@@ -2522,7 +2523,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3263,7 +3264,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3321,7 +3322,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3342,7 +3343,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3434,7 +3435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3792,7 +3793,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4487,7 +4488,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "rdrop"
 path = "src/main.rs"
 
 [dependencies]
-iroh-rings = { version = "0.3.0", features = ["redb", "fs", "mem"] }
+iroh-rings = { git = "https://github.com/rikettsie/iroh-rings.git", branch = "feat/r-w-d-rebac-permission-model", features = ["redb", "fs", "mem"] }
 
 # Core components: transport protocol, chunking, concurrency
 iroh = "0.98.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ name = "rdrop"
 path = "src/main.rs"
 
 [dependencies]
-iroh-rings = { git = "https://github.com/rikettsie/iroh-rings.git", branch = "feat/r-w-d-rebac-permission-model", features = ["redb", "fs", "mem"] }
+iroh-rings = { version = "0.5.0", features = ["redb", "fs", "mem"] }
 
 # Core components: transport protocol, chunking, concurrency
 iroh = "0.98.2"

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ To share a file, associate it with one or more rings and get back an `rdrop://` 
 Only peers who are members of those rings can download it.
 Transfers resume automatically if interrupted — no verified data is re-transferred after a crash or disconnect.
 
-Access control is enforced at the connection level via an ALPN protocol (`/iroh-rings/1`). When a peer requests a blob, the sender checks whether that peer's `peer-id` belongs to any ring the blob is associated with. If not, the transfer is denied before any data is sent.
+Access control is enforced at the connection level via an ALPN protocol (`/iroh-rings/2`). Ring–resource associations carry typed permissions (`Read`, `Write`, `Delete`). When a peer requests to download a blob, the sender checks that the peer holds `Read` permission on it — either through ring membership or the built-in open ring — and denies the transfer before any data is sent if not.
 
 ## Features
 

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -3,8 +3,8 @@
 //! Wraps:
 //!  - an iroh `Endpoint`        — QUIC, NAT traversal, relay fallback
 //!  - an iroh-blobs `FsStore`   — BLAKE3 chunking, outboard, bitfield tracking
-//!  - a `RingGate`              — custom ALPN with per-blob access control
-//!  - a `Registry`              — ring membership and file tagging
+//!  - a `RingGate`              — custom ALPN with permission-typed access control
+//!  - a `Registry`              — ring membership and permission-typed resource associations
 
 use std::{
     collections::HashSet,
@@ -25,10 +25,11 @@ use iroh_blobs::{
 use tracing::info;
 use walkdir::WalkDir;
 
-use super::protocol::{RingGate, RingReceiver, SC_ALPN};
+use super::protocol::{RingGate, RingReceiver, ALPN};
 use super::ticket::ShareTicket;
 use crate::config::Config;
 use iroh_rings::FsTransfer;
+use iroh_rings::Permission;
 use iroh_rings::Registry;
 use iroh_rings::OPEN_RING_NAME;
 
@@ -48,7 +49,7 @@ pub struct Node<R> {
     pub endpoint: Endpoint,
     /// The iroh-blobs persistent store — holds all locally imported and received blobs.
     pub store: FsStore,
-    /// The ring registry — tracks ring membership and per-blob access tags.
+    /// The ring registry — tracks ring membership and permission-typed resource associations.
     pub registry: R,
     router: Router,
 }
@@ -124,9 +125,7 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
             FsTransfer::new(store.clone(), registry.clone()),
         );
 
-        let router = Router::builder(endpoint.clone())
-            .accept(SC_ALPN, gate)
-            .spawn();
+        let router = Router::builder(endpoint.clone()).accept(ALPN, gate).spawn();
 
         endpoint.online().await;
         info!(peer_id = %endpoint.id(), "node online");
@@ -243,7 +242,8 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
     /// List blobs in the local store as `(hash, format, tag_name)` triples.
     ///
     /// When `peer` is supplied only blobs accessible to that peer are returned
-    /// (i.e. the blob is tagged with at least one ring the peer belongs to).
+    /// (i.e. blobs associated with at least one ring that both includes the peer
+    /// and grants [`Permission::Read`]).
     /// When `rings` is supplied only blobs tagged with at least one of those
     /// ring names are returned (OR semantics).  When both are given the
     /// filters are combined: a blob must satisfy both independently.
@@ -278,12 +278,14 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
             for (hash, format, name) in blobs {
                 let blob_rings = self.registry.list_resource_rings(*hash.as_bytes())?;
                 if let Some(ref rset) = ring_names {
-                    if !blob_rings.iter().any(|r| rset.contains(r.as_str())) {
+                    if !blob_rings.iter().any(|(r, _)| rset.contains(r.as_str())) {
                         continue;
                     }
                 }
                 if let Some(ref pset) = peer_rings {
-                    if !blob_rings.iter().any(|r| pset.contains(r.as_str())) {
+                    if !blob_rings.iter().any(|(r, perms)| {
+                        pset.contains(r.as_str()) && perms.contains(&Permission::Read)
+                    }) {
                         continue;
                     }
                 }
@@ -433,7 +435,7 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
 
         let conn = self
             .endpoint
-            .connect(ticket.node_addr().clone(), SC_ALPN)
+            .connect(ticket.node_addr().clone(), ALPN)
             .await
             .context("connecting to sender")?;
 

--- a/src/core/protocol.rs
+++ b/src/core/protocol.rs
@@ -19,8 +19,9 @@ use iroh_blobs::{
 };
 use tracing::info;
 
-pub(crate) use iroh_rings::protocol::{encode_request, RingGate, Status, SC_ALPN};
+pub(crate) use iroh_rings::protocol::{encode_request, RingGate, Status};
 pub(crate) use iroh_rings::transfers::fs::encode_ranges_wire;
+pub(crate) use iroh_rings::{Permission, ALPN};
 
 // export_bao emits an 8-byte little-endian content size before the bao tree,
 // so the receiver knows the total before any leaf data arrives.
@@ -105,7 +106,8 @@ impl RingReceiver {
         let missing = ChunkRanges::all();
 
         let (mut send, mut recv) = conn.open_bi().await?;
-        send.write_all(&encode_request(hash.as_bytes())?).await?;
+        send.write_all(&encode_request(hash.as_bytes(), Permission::Read)?)
+            .await?;
         send.write_all(&encode_ranges_wire(&already_have)).await?;
         send.finish()?;
 
@@ -229,20 +231,20 @@ impl RingReceiver {
 mod tests {
     use iroh_blobs::Hash;
 
-    use super::encode_request;
-    use super::SC_ALPN;
+    use super::{encode_request, Permission, ALPN};
 
     #[test]
     fn request_encoding_is_length_prefixed() {
         let hash = Hash::from_bytes([0xab; 32]);
-        let encoded = encode_request(hash.as_bytes()).unwrap();
+        let encoded = encode_request(hash.as_bytes(), Permission::Read).unwrap();
         let len = u16::from_le_bytes(encoded[..2].try_into().unwrap());
         assert_eq!(len as usize, 32);
-        assert_eq!(&encoded[2..], hash.as_bytes());
+        // wire format: [u16 len][resource id][op byte]
+        assert_eq!(&encoded[2..2 + 32], hash.as_bytes());
     }
 
     #[test]
-    fn sc_alpn_is_iroh_rings_v1() {
-        assert_eq!(SC_ALPN, b"/iroh-rings/1");
+    fn alpn_is_iroh_rings_v2() {
+        assert_eq!(ALPN, b"/iroh-rings/2");
     }
 }

--- a/src/daemon/server/handlers/blob.rs
+++ b/src/daemon/server/handlers/blob.rs
@@ -1,7 +1,7 @@
 use std::path::PathBuf;
 
 use anyhow::Result;
-use iroh_rings::{Registry, OPEN_RING_NAME};
+use iroh_rings::{Permission, Registry, OPEN_RING_NAME};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -50,13 +50,14 @@ pub(crate) async fn handle_import<R: Registry + Clone + Send + Sync + 'static>(
             .await;
         } else {
             send(tx, Event::line(req_id, "Already tagged:")).await;
-            for r in &existing {
+            for (r, _) in &existing {
                 send(tx, Event::line(req_id, format_ring(r))).await;
             }
         }
     } else {
         for ring in &effective_rings {
-            node.registry.add_ring_to_resource(*hash.as_bytes(), ring)?;
+            node.registry
+                .add_ring_to_resource(*hash.as_bytes(), ring, &[Permission::Read])?;
             if ring == OPEN_RING_NAME {
                 send(
                     tx,
@@ -122,7 +123,7 @@ pub(crate) async fn handle_blob_list<R: Registry + Clone + Send + Sync + 'static
                 )
                 .await;
             } else {
-                let names: Vec<_> = rings.iter().map(|r| r.as_str().to_owned()).collect();
+                let names: Vec<_> = rings.iter().map(|(r, _)| r.as_str().to_owned()).collect();
                 send(
                     tx,
                     Event::line(req_id, format!("    rings:  {}", names.join(", "))),

--- a/src/daemon/server/handlers/tag.rs
+++ b/src/daemon/server/handlers/tag.rs
@@ -1,5 +1,5 @@
 use anyhow::Result;
-use iroh_rings::{Registry, OPEN_RING_NAME};
+use iroh_rings::{Permission, Registry, OPEN_RING_NAME};
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
@@ -26,7 +26,8 @@ pub(crate) async fn handle_tag<R: Registry + Clone + Send + Sync + 'static>(
 
     let hash = resolve_target(node, &target).await?;
     for ring in &rings {
-        node.registry.add_ring_to_resource(*hash.as_bytes(), ring)?;
+        node.registry
+            .add_ring_to_resource(*hash.as_bytes(), ring, &[Permission::Read])?;
         send(
             tx,
             Event::line(req_id, format!("Tagged {hash} with ring '{ring}'")),
@@ -34,8 +35,11 @@ pub(crate) async fn handle_tag<R: Registry + Clone + Send + Sync + 'static>(
         .await;
     }
     if open {
-        node.registry
-            .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME)?;
+        node.registry.add_ring_to_resource(
+            *hash.as_bytes(),
+            OPEN_RING_NAME,
+            &[Permission::Read],
+        )?;
         send(
             tx,
             Event::line(
@@ -72,7 +76,7 @@ pub(crate) async fn handle_tags<R: Registry + Clone + Send + Sync + 'static>(
             Event::line(req_id, format!("{}: {} rings:", hash, rings.len())),
         )
         .await;
-        for ring in &rings {
+        for (ring, _) in &rings {
             send(tx, Event::line(req_id, format_ring(ring))).await;
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //! │  │  │    └───────┬──────┘       │  │  │
 //! │  │  │            ↕              │  │  │
 //! │  │  │         RingGate          │  │  │
-//! │  │  │   (ALPN /iroh-rings/1)    │  │  │
+//! │  │  │   (ALPN /iroh-rings/2)    │  │  │
 //! │  │  │            ↕              │  │  │
 //! │  │  │        Endpoint           │  │  │
 //! │  │  │       (QUIC/iroh)         │  │  │
@@ -38,9 +38,12 @@
 //! ```
 //!
 //! A [`core::Node`] wraps an iroh QUIC endpoint, an iroh-blobs persistent blob
-//! store, a `Registry` that tracks ring membership, and a `RingGate` that
-//! enforces access control: a blob is only served to a peer whose
-//! [`EndpointId`] is a member of at least one ring the blob is tagged with.
+//! store, a `Registry` that tracks ring membership and permission-typed
+//! resource associations, and a `RingGate` that enforces access control: a
+//! blob is only served to a peer that holds [`Permission::Read`] on it — either
+//! through ring membership or the built-in open ring.
+//!
+//! [`Permission::Read`]: iroh_rings::Permission
 //!
 //! The [`daemon`] module runs a `Node` as a background TCP server so that the
 //! CLI can talk to it over a local IPC connection.

--- a/tests/blob_management.rs
+++ b/tests/blob_management.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use iroh_rings::{Registry, OPEN_RING_NAME};
+use iroh_rings::{Permission, Registry, OPEN_RING_NAME};
 use tempfile::TempDir;
 
 #[tokio::test]
@@ -86,7 +86,7 @@ async fn export_without_ticket_name_uses_hash_hex_not_download() {
     sender
         .node
         .registry
-        .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME)
+        .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME, &[Permission::Read])
         .unwrap();
 
     // Simulate what old `blob list` produced — ticket with no name.

--- a/tests/ring_gate.rs
+++ b/tests/ring_gate.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use iroh_rings::{Registry, OPEN_RING_NAME};
+use iroh_rings::{Permission, Registry, OPEN_RING_NAME};
 use tempfile::TempDir;
 
 #[tokio::test]
@@ -15,7 +15,7 @@ async fn open_ring_allows_any_peer() {
     sender
         .node
         .registry
-        .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME)
+        .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME, &[Permission::Read])
         .unwrap();
 
     let ticket = sender
@@ -51,7 +51,7 @@ async fn private_ring_allows_member() {
     sender
         .node
         .registry
-        .add_ring_to_resource(*hash.as_bytes(), "friends")
+        .add_ring_to_resource(*hash.as_bytes(), "friends", &[Permission::Read])
         .unwrap();
 
     let ticket = sender
@@ -83,7 +83,7 @@ async fn private_ring_denies_non_member() {
     sender
         .node
         .registry
-        .add_ring_to_resource(*hash.as_bytes(), "vip")
+        .add_ring_to_resource(*hash.as_bytes(), "vip", &[Permission::Read])
         .unwrap();
 
     let ticket = sender.node.make_ticket(hash, format, None);

--- a/tests/transfer.rs
+++ b/tests/transfer.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use iroh_rings::{Registry, OPEN_RING_NAME};
+use iroh_rings::{Permission, Registry, OPEN_RING_NAME};
 use tempfile::TempDir;
 
 #[tokio::test]
@@ -16,7 +16,7 @@ async fn file_content_matches_after_transfer() {
     sender
         .node
         .registry
-        .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME)
+        .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME, &[Permission::Read])
         .unwrap();
 
     let ticket = sender
@@ -49,7 +49,7 @@ async fn directory_contents_match_after_transfer() {
     sender
         .node
         .registry
-        .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME)
+        .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME, &[Permission::Read])
         .unwrap();
 
     let ticket = sender.node.make_ticket(hash, format, Some("mydir".into()));
@@ -83,7 +83,7 @@ async fn already_complete_blob_skips_transfer() {
     sender
         .node
         .registry
-        .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME)
+        .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME, &[Permission::Read])
         .unwrap();
 
     let ticket = sender


### PR DESCRIPTION
/iroh-rings/2 protocol supports {Read,Write,Delete} resource-oriented semantics.
ringdrop adapts to the new three-permission behavior. Basically using the {Read} permission.