### PR TITLE
Support `cargo binstall`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,16 +17,12 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            archive: rdrop-x86_64-unknown-linux-gnu.tar.gz
           - os: macos-latest
             target: aarch64-apple-darwin
-            archive: rdrop-aarch64-apple-darwin.tar.gz
           - os: macos-latest
             target: x86_64-apple-darwin
-            archive: rdrop-x86_64-apple-darwin.tar.gz
           - os: windows-latest
             target: x86_64-pc-windows-msvc
-            archive: rdrop-x86_64-pc-windows-msvc.zip
     steps:
       - uses: actions/checkout@v4
 
@@ -44,20 +40,26 @@ jobs:
       - name: Package (Unix)
         if: runner.os != 'Windows'
         run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          ARCHIVE="rdrop-${VERSION}-${{ matrix.target }}.tar.gz"
           cp target/${{ matrix.target }}/release/rdrop rdrop
-          tar czf ${{ matrix.archive }} rdrop
+          tar czf "$ARCHIVE" rdrop
+          echo "ARCHIVE=$ARCHIVE" >> "$GITHUB_ENV"
 
       - name: Package (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          $VERSION = "${{ github.ref_name }}".TrimStart('v')
+          $ARCHIVE = "rdrop-${VERSION}-${{ matrix.target }}.zip"
           Copy-Item target\${{ matrix.target }}\release\rdrop.exe rdrop.exe
-          Compress-Archive rdrop.exe ${{ matrix.archive }}
+          Compress-Archive rdrop.exe $ARCHIVE
+          "ARCHIVE=$ARCHIVE" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.target }}
-          path: ${{ matrix.archive }}
+          path: ${{ env.ARCHIVE }}
 
   publish:
     name: Publish
@@ -121,12 +123,12 @@ jobs:
           TAG: ${{ github.ref_name }}
         run: |
           VERSION="${TAG#v}"
-          SHA256=$(curl -sL "https://github.com/rikettsie/ringdrop/releases/download/${TAG}/rdrop-x86_64-pc-windows-msvc.zip" | sha256sum | cut -d' ' -f1)
+          SHA256=$(curl -sL "https://github.com/rikettsie/ringdrop/releases/download/${TAG}/rdrop-${VERSION}-x86_64-pc-windows-msvc.zip" | sha256sum | cut -d' ' -f1)
           git clone "https://x-access-token:${TAP_TOKEN}@github.com/rikettsie/scoop-bucket.git"
           cd scoop-bucket
           jq --arg version "$VERSION" \
              --arg hash "$SHA256" \
-             --arg url "https://github.com/rikettsie/ringdrop/releases/download/${TAG}/rdrop-x86_64-pc-windows-msvc.zip" \
+             --arg url "https://github.com/rikettsie/ringdrop/releases/download/${TAG}/rdrop-${VERSION}-x86_64-pc-windows-msvc.zip" \
              '.version = $version | .architecture."64bit".hash = $hash | .architecture."64bit".url = $url' \
              bucket/rdrop.json > tmp.json && mv tmp.json bucket/rdrop.json
           git config user.name "github-actions[bot]"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,11 @@ uuid = { version = "1", features = ["v4", "serde"] }
 
 [dev-dependencies]
 tempfile = "3"
+
+[package.metadata.binstall]
+pkg-url = "{ repo }/releases/download/v{ version }/rdrop-{ version }-{ target }.{ archive-format }"
+bin-dir = "rdrop{ binary-ext }"
+pkg-fmt = "tgz"
+
+[package.metadata.binstall.overrides.x86_64-pc-windows-msvc]
+pkg-fmt = "zip"

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Access control is enforced at the connection level. Ring–resource associations
 | Linux | `cargo install ringdrop` |
 | macOS | `brew tap rikettsie/tap && brew install rdrop` |
 | Windows (PowerShell) | `scoop bucket add rikettsie https://github.com/rikettsie/scoop-bucket; scoop install rdrop` |
+| All platforms (pre-built bin) | `cargo binstall rdrop` |
 
 For prerequisites, alternative methods, and troubleshooting see [docs/install.md](docs/install.md).
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -1,5 +1,18 @@
 # Installation
 
+## Via cargo-binstall (all platforms)
+
+If you have [`cargo-binstall`](https://github.com/cargo-bins/cargo-binstall) installed, you can skip compilation entirely:
+
+```sh
+cargo binstall rdrop
+```
+
+> **Note:** pre-built binary downloads are supported from **v0.11.0** onwards.
+> Installing an older version falls back to compiling from source automatically.
+
+---
+
 ## Linux
 
 ### Via Cargo (recommended)


### PR DESCRIPTION
For a faster installation I added support for `binstall`.

This meant to:
- Make the version explicit in archive filename produced by the CI;
- Add custom metadata in `Cargo.toml`, because the binary name (`rdrop`) is different from the repository name (`ringdrop`).
