### PR TITLE
Support custom minimal relays

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -224,6 +224,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "backon"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,6 +359,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex",
 ]
 
@@ -366,7 +390,7 @@ checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "rand_core",
+ "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -432,6 +456,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "cmov"
@@ -630,7 +663,7 @@ dependencies = [
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
- "rand_core",
+ "rand_core 0.10.1",
  "rustc_version",
  "serde",
  "subtle",
@@ -870,6 +903,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "ed25519"
 version = "3.0.0-rc.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -888,7 +927,7 @@ checksum = "053618a4c3d3bc24f188aa660ae75a46eeab74ef07fb415c61431e5e7cd4749b"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
- "rand_core",
+ "rand_core 0.10.1",
  "serde",
  "sha2",
  "signature",
@@ -1003,6 +1042,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1189,6 +1234,20 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
@@ -1196,8 +1255,8 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
- "rand_core",
+ "r-efi 6.0.0",
+ "rand_core 0.10.1",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -1324,7 +1383,7 @@ dependencies = [
  "idna",
  "ipnet",
  "jni 0.22.4",
- "rand",
+ "rand 0.10.1",
  "rustls",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1346,7 +1405,7 @@ dependencies = [
  "jni 0.22.4",
  "once_cell",
  "prefix-trie",
- "rand",
+ "rand 0.10.1",
  "ring",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1371,7 +1430,7 @@ dependencies = [
  "ndk-context",
  "once_cell",
  "parking_lot",
- "rand",
+ "rand 0.10.1",
  "resolv-conf",
  "rustls",
  "smallvec",
@@ -1655,7 +1714,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "log",
- "rand",
+ "rand 0.10.1",
  "tokio",
  "url",
  "xmltree",
@@ -1762,7 +1821,7 @@ dependencies = [
  "pkcs8",
  "portable-atomic",
  "portmapper",
- "rand",
+ "rand 0.10.1",
  "reqwest",
  "rustc-hash",
  "rustls",
@@ -1795,7 +1854,7 @@ dependencies = [
  "ed25519-dalek",
  "getrandom 0.4.2",
  "n0-error",
- "rand",
+ "rand 0.10.1",
  "serde",
  "sha2",
  "url",
@@ -1832,7 +1891,7 @@ dependencies = [
  "nested_enum_utils",
  "noq",
  "postcard",
- "rand",
+ "rand 0.10.1",
  "range-collections",
  "redb 2.6.3",
  "ref-cast",
@@ -1927,7 +1986,7 @@ dependencies = [
  "num_enum",
  "pin-project",
  "postcard",
- "rand",
+ "rand 0.10.1",
  "reqwest",
  "rustls",
  "rustls-pki-types",
@@ -2098,6 +2157,16 @@ checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
 ]
 
 [[package]]
@@ -2490,7 +2559,7 @@ dependencies = [
  "getrandom 0.4.2",
  "identity-hash",
  "lru-slab",
- "rand",
+ "rand 0.10.1",
  "ring",
  "rustc-hash",
  "rustls",
@@ -2855,7 +2924,7 @@ dependencies = [
  "n0-error",
  "netwatch",
  "num_enum",
- "rand",
+ "rand 0.10.1",
  "serde",
  "smallvec",
  "socket2",
@@ -2916,6 +2985,15 @@ name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prefix-trie"
@@ -2998,6 +3076,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "aws-lc-rs",
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,9 +3142,25 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core 0.9.5",
+]
 
 [[package]]
 name = "rand"
@@ -3020,7 +3170,26 @@ checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
  "chacha20",
  "getrandom 0.4.2",
- "rand_core",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -3163,6 +3332,7 @@ dependencies = [
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier 0.7.0",
@@ -3218,6 +3388,7 @@ dependencies = [
  "iroh-io",
  "iroh-rings",
  "redb 4.1.0",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_millis",
@@ -3273,6 +3444,7 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -3358,6 +3530,7 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -3981,7 +4154,7 @@ dependencies = [
  "getrandom 0.4.2",
  "http",
  "httparse",
- "rand",
+ "rand 0.10.1",
  "ring",
  "rustls-pki-types",
  "sha1_smol",
@@ -4981,6 +5154,26 @@ dependencies = [
  "quote",
  "syn 2.0.117",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.49"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ dirs-next = "2"               # home directory for default data path
 indicatif = "0.17"            # terminal progress bars
 serde_millis = "0.1.1"
 uuid = { version = "1", features = ["v4", "serde"] }
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,20 @@ Full reference: [docs/cli.md](docs/cli.md)
 | `rdrop grant` | Grant specific rights to remote peers on your local node |
 | `rdrop remote` | Perform a command in a remote node |
 
+## Custom relay
+
+By default ringdrop uses the public relay infrastructure provided by [Number 0](https://n0.computer) (`relay.iroh.network`). You can point the node to a relay you control by adding a `relay_url` field to `config.json` (located in your data directory, `~/.local/share/ringdrop/` by default):
+
+```json
+{
+  "relay_url": "https://relay.yourdomain.com"
+}
+```
+
+When the field is absent the default n0 relay is used. An invalid URL or an unreachable relay causes the daemon to fail at startup with a clear error rather than silently falling back.
+
+> **Self-hosting a relay**: see the [iroh-relay README](https://github.com/n0-computer/iroh/tree/main/iroh-relay) for instructions on running your own relay instance. Peer discovery (pkarr/DNS) continues to use n0's `iroh.link` infrastructure regardless of which relay you choose.
+
 ## Contributing
 
 If you have ideas/contributions or anything is not working the way you expect (in which case, please include an output with `RUST_LOG=debug`) and feel free to open an issue or PR.

--- a/src/cli/command/daemon.rs
+++ b/src/cli/command/daemon.rs
@@ -59,7 +59,9 @@ pub(crate) async fn run_start(data_dir: &Path) -> Result<()> {
             let node_id = query_node_info(&client)
                 .await
                 .unwrap_or_else(|_| "?".into());
+            let relay_label = relay_label(data_dir);
             println!("Rdrop daemon started. Node ID: {node_id}");
+            println!("Relay: {relay_label}");
             return Ok(());
         }
     }
@@ -96,8 +98,12 @@ pub(crate) async fn run_status(data_dir: &Path) -> Result<()> {
         return Ok(());
     }
 
+    let relay_label = relay_label(data_dir);
     match query_node_info(&client).await {
-        Ok(id) => println!("Rdrop daemon running. Node ID: {id}"),
+        Ok(id) => {
+            println!("Rdrop daemon running. Node ID: {id}");
+            println!("Relay: {relay_label}");
+        }
         Err(e) => println!("Rdrop daemon running but failed to get node info: {e}"),
     }
     Ok(())
@@ -111,6 +117,20 @@ pub(crate) async fn run_serve(data_dir: &Path) -> Result<()> {
     let node = Node::start(data_dir, cfg, registry).await?;
 
     DaemonServer::bind(node, port).await?.run().await
+}
+
+/// Returns a human-readable relay label for display in `daemon start` and `daemon status`.
+///
+/// Reads the config from disk; if the config cannot be loaded (e.g. file missing), falls
+/// back to `"default (n0)"` so that status output is never blocked by a config error.
+fn relay_label(data_dir: &Path) -> String {
+    match Config::load_or_create(data_dir) {
+        Ok(cfg) => match cfg.relay_url {
+            Some(url) => format!("{url} (custom)"),
+            None => "default (n0)".to_owned(),
+        },
+        Err(_) => "default (n0)".to_owned(),
+    }
 }
 
 async fn query_node_info(client: &DaemonClient) -> Result<String> {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -92,7 +92,7 @@ struct Cli {
     command: Cmd,
 }
 
-/// Parse CLI arguments and dispatch the requested command to the daemon.
+/// Parses CLI arguments and dispatches the requested command to the daemon.
 ///
 /// # Errors
 ///

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@
 use std::path::Path;
 
 use anyhow::{Context, Result};
-use iroh::{EndpointId, SecretKey};
+use iroh::{EndpointId, RelayUrl, SecretKey};
 use serde::{Deserialize, Serialize};
 
 /// Persistent node configuration, stored as JSON in the data directory.
@@ -22,6 +22,13 @@ pub struct Config {
     /// TCP port the daemon listens on for local IPC connections (default: 60001).
     #[serde(default = "Config::default_daemon_port")]
     pub daemon_port: u16,
+    /// Custom iroh relay URL. When absent the node uses n0's public relay infrastructure.
+    ///
+    /// Must be a valid HTTPS URL pointing to a running
+    /// [iroh-relay](https://github.com/n0-computer/iroh/tree/main/iroh-relay) instance.
+    /// An invalid URL is rejected at daemon start with a clear error.
+    #[serde(default)]
+    pub relay_url: Option<RelayUrl>,
 }
 
 impl Config {
@@ -41,7 +48,8 @@ impl Config {
     ///
     /// # Errors
     ///
-    /// Returns an error if the file exists but cannot be read or parsed.
+    /// Returns an error if the file exists but cannot be read, cannot be parsed,
+    /// or contains a `relay_url` that is not a valid URL.
     pub fn load_or_create(data_dir: &Path) -> Result<Self> {
         let path = data_dir.join("config.json");
         if path.exists() {
@@ -52,6 +60,7 @@ impl Config {
             let cfg = Config {
                 secret_key: SecretKey::generate(),
                 daemon_port: Self::default_daemon_port(),
+                relay_url: None,
             };
             let raw = serde_json::to_string_pretty(&cfg)?;
             std::fs::write(&path, raw).with_context(|| format!("writing {}", path.display()))?;
@@ -101,5 +110,39 @@ mod tests {
         std::fs::write(dir.path().join("config.json"), b"not valid json").unwrap();
         let err = Config::load_or_create(dir.path()).unwrap_err();
         assert!(err.to_string().contains("parsing"));
+    }
+
+    #[test]
+    fn relay_url_absent_defaults_to_none() {
+        let dir = tmpdir();
+        let key = iroh::SecretKey::generate();
+        let legacy = serde_json::json!({ "secret_key": key });
+        std::fs::write(dir.path().join("config.json"), legacy.to_string()).unwrap();
+        let cfg = Config::load_or_create(dir.path()).unwrap();
+        assert!(cfg.relay_url.is_none());
+    }
+
+    #[test]
+    fn relay_url_invalid_value_returns_parse_error() {
+        let dir = tmpdir();
+        let key = iroh::SecretKey::generate();
+        let bad = serde_json::json!({ "secret_key": key, "relay_url": "not a url" });
+        std::fs::write(dir.path().join("config.json"), bad.to_string()).unwrap();
+        let err = Config::load_or_create(dir.path()).unwrap_err();
+        assert!(err.to_string().contains("parsing"));
+    }
+
+    #[test]
+    fn relay_url_valid_value_parses_correctly() {
+        let dir = tmpdir();
+        let key = iroh::SecretKey::generate();
+        let cfg_json =
+            serde_json::json!({ "secret_key": key, "relay_url": "https://relay.example.com" });
+        std::fs::write(dir.path().join("config.json"), cfg_json.to_string()).unwrap();
+        let cfg = Config::load_or_create(dir.path()).unwrap();
+        assert_eq!(
+            cfg.relay_url.unwrap().to_string(),
+            "https://relay.example.com/"
+        );
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,7 +43,7 @@ impl Config {
         self.secret_key.public()
     }
 
-    /// Load configuration from `data_dir/config.json`, creating it with a fresh
+    /// Loads configuration from `data_dir/config.json`, creating it with a fresh
     /// secret key if the file does not yet exist.
     ///
     /// # Errors

--- a/src/core/grants.rs
+++ b/src/core/grants.rs
@@ -58,7 +58,7 @@ impl fmt::Display for Privilege {
 impl TryFrom<&str> for Privilege {
     type Error = anyhow::Error;
 
-    /// Parse a privilege from its canonical string representation.
+    /// Parses a privilege from its canonical string representation.
     ///
     /// # Errors
     ///
@@ -80,7 +80,7 @@ pub struct GrantStore {
 }
 
 impl GrantStore {
-    /// Open (or create) the grant store at `path`, backed by a dedicated database.
+    /// Opens (or creates) the grant store at `path`, backed by a dedicated database.
     ///
     /// Convenience wrapper around [`Self::from_db`] for standalone and test use.
     ///
@@ -93,7 +93,7 @@ impl GrantStore {
         Self::from_db(db)
     }
 
-    /// Attach the grant store to an existing shared database.
+    /// Attaches the grant store to an existing shared database.
     ///
     /// Creates the `GRANTS` table if it does not yet exist. Use this when
     /// `GrantStore` and `PeerStore` share the same `local.redb` file.
@@ -111,7 +111,7 @@ impl GrantStore {
         Ok(Self { db })
     }
 
-    /// Grant `privilege` to `peer`.
+    /// Grants `privilege` to `peer`.
     ///
     /// Idempotent: granting an already-granted privilege is a no-op.
     ///
@@ -131,7 +131,7 @@ impl GrantStore {
         Ok(())
     }
 
-    /// Revoke `privilege` from `peer`.
+    /// Revokes `privilege` from `peer`.
     ///
     /// Idempotent: revoking a non-existent grant is a no-op.
     ///
@@ -192,7 +192,7 @@ fn grant_key(privilege: Privilege, peer: &EndpointId) -> Vec<u8> {
     key
 }
 
-/// Decode a raw key back into `(Privilege, EndpointId)`.
+/// Decodes a raw key back into `(Privilege, EndpointId)`.
 fn decode_grant_key(key: &[u8]) -> Result<(Privilege, EndpointId)> {
     let sep = key
         .iter()

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -18,7 +18,12 @@ use std::{
 
 use anyhow::{Context, Result};
 use futures_lite::StreamExt;
-use iroh::{endpoint::presets, protocol::Router, Endpoint, EndpointAddr};
+use iroh::{
+    address_lookup::{DnsAddressLookup, PkarrPublisher},
+    endpoint::presets,
+    protocol::Router,
+    Endpoint, EndpointAddr, RelayMode,
+};
 use iroh_blobs::{
     api::blobs::{AddPathOptions, BlobStatus, ImportMode},
     format::collection::Collection,
@@ -102,13 +107,32 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
     ///
     /// # Errors
     ///
-    /// Returns an error if the QUIC endpoint cannot bind, or if the blob store
-    /// cannot be opened or created.
+    /// Returns an error if the QUIC endpoint cannot bind, if the blob store
+    /// cannot be opened or created, or if a custom `relay_url` is configured
+    /// but the relay is unreachable at startup.
     pub async fn start(data_dir: impl AsRef<Path>, cfg: Config, registry: R) -> Result<Self> {
         let data_dir = data_dir.as_ref().to_path_buf();
         tokio::fs::create_dir_all(&data_dir).await?;
 
-        let endpoint = Endpoint::builder(presets::N0)
+        let relay_mode = match &cfg.relay_url {
+            None => RelayMode::Default,
+            Some(url) => {
+                // Probe the relay before binding so a misconfigured URL fails fast
+                // with a clear error rather than silently falling back.
+                // RELAY_PROBE_PATH in iroh-relay is "/ping".
+                reqwest::get(format!("{}ping", url))
+                    .await
+                    .with_context(|| {
+                        format!("relay probe failed for {url} — check relay_url in config.json")
+                    })?;
+                RelayMode::Custom(url.clone().into())
+            }
+        };
+
+        let endpoint = Endpoint::builder(presets::Minimal)
+            .address_lookup(PkarrPublisher::n0_dns())
+            .address_lookup(DnsAddressLookup::n0_dns())
+            .relay_mode(relay_mode)
             .secret_key(cfg.secret_key)
             .bind()
             .await

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -99,7 +99,7 @@ fn peer_ring_set<R: Registry>(registry: &R, peer: &str) -> Result<HashSet<String
 }
 
 impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
-    /// Start a node, binding a QUIC endpoint and loading the blob store from `data_dir`.
+    /// Starts a node, binding a QUIC endpoint and loading the blob store from `data_dir`.
     ///
     /// The node is immediately reachable for inbound connections once this
     /// returns. The blob store is created under `data_dir/blobs/` if it does
@@ -192,7 +192,7 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
         self.endpoint.addr()
     }
 
-    /// Import a single file into the blob store.
+    /// Imports a single file into the blob store.
     ///
     /// The file is chunked, BLAKE3-hashed, and pinned with a named tag (the
     /// leaf filename, i.e. `path.file_name()`). Returns the root hash and `BlobFormat::Raw`.
@@ -228,7 +228,7 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
         Ok((hash, format))
     }
 
-    /// Import a directory into the blob store as an iroh-blobs collection.
+    /// Imports a directory into the blob store as an iroh-blobs collection.
     ///
     /// Each file under `dir` is imported individually; the resulting hashes are
     /// assembled into a `HashSeq` collection pinned under the directory name.
@@ -344,7 +344,7 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
         Ok(blobs)
     }
 
-    /// Remove a blob from the local store by deleting its named tags.
+    /// Removes a blob from the local store by deleting its named tags.
     ///
     /// Ring tags in the registry must be removed separately by the caller
     /// before invoking this method. Disk space is reclaimed on the next GC
@@ -419,7 +419,7 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
         decode_entries(&mut recv).await
     }
 
-    /// Import a file or directory, dispatching to [`Node::import_file`] or
+    /// Imports a file or directory, dispatching to [`Node::import_file`] or
     /// [`Node::import_directory`] based on whether `path` is a file or a dir.
     ///
     /// # Errors

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -525,6 +525,7 @@ mod tests {
         let cfg = Config {
             secret_key: SecretKey::generate(),
             daemon_port: 60001,
+            relay_url: None,
         };
         let node = Node::start(dir.path(), cfg, InMemoryRegistry::default())
             .await

--- a/src/core/peers.rs
+++ b/src/core/peers.rs
@@ -43,7 +43,7 @@ pub struct PeerStore {
 }
 
 impl PeerStore {
-    /// Open (or create) the peer store at `path`, backed by a dedicated database.
+    /// Opens (or creates) the peer store at `path`, backed by a dedicated database.
     ///
     /// Convenience wrapper around [`Self::from_db`] for standalone and test use.
     ///
@@ -56,7 +56,7 @@ impl PeerStore {
         Self::from_db(db)
     }
 
-    /// Attach the peer store to an existing shared database.
+    /// Attaches the peer store to an existing shared database.
     ///
     /// Creates the `PEERS` table if it does not yet exist. Use this when
     /// `PeerStore` and `GrantStore` share the same `local.redb` file.
@@ -74,7 +74,7 @@ impl PeerStore {
         Ok(Self { db })
     }
 
-    /// Add `peer` to the store with an optional nickname, or update the
+    /// Adds `peer` to the store with an optional nickname, or updates the
     /// nickname if the peer is already known.
     ///
     /// Passing `nickname: None` clears any existing nickname.
@@ -94,7 +94,7 @@ impl PeerStore {
         Ok(())
     }
 
-    /// Ensure `peer` is in the store.
+    /// Ensures `peer` is in the store.
     ///
     /// If the peer is already present the existing nickname is preserved. If
     /// absent the peer is added with no nickname.
@@ -117,7 +117,7 @@ impl PeerStore {
         self.upsert(peer, None)
     }
 
-    /// Set or update the nickname for an already-known peer.
+    /// Sets or updates the nickname for an already-known peer.
     ///
     /// # Errors
     ///
@@ -145,7 +145,7 @@ impl PeerStore {
         Ok(())
     }
 
-    /// Look up a peer by identity.
+    /// Looks up a peer by identity.
     ///
     /// Returns `None` if the peer is not in the store, `Some(None)` if the
     /// peer is known but has no nickname, and `Some(Some(nickname))` if a
@@ -196,7 +196,7 @@ impl PeerStore {
         Ok(out)
     }
 
-    /// Remove `peer` from the store.
+    /// Removes `peer` from the store.
     ///
     /// # Errors
     ///

--- a/src/core/protocol/catalog.rs
+++ b/src/core/protocol/catalog.rs
@@ -89,7 +89,7 @@ impl<R> fmt::Debug for CatalogHandler<R> {
 }
 
 impl<R: Registry + Clone + Send + Sync + 'static> CatalogHandler<R> {
-    /// Create a new handler backed by the given store, registry, grant store, and endpoint.
+    /// Creates a new handler backed by the given store, registry, grant store, and endpoint.
     pub(crate) fn new(store: FsStore, registry: R, grants: GrantStore, endpoint: Endpoint) -> Self {
         CatalogHandler {
             store,
@@ -175,7 +175,7 @@ impl<R: Registry + Clone + Send + Sync + 'static> ProtocolHandler for CatalogHan
     }
 }
 
-/// Decode [`BLOB_LIST`] entries streamed by the server after the ALLOWED byte.
+/// Decodes [`BLOB_LIST`] entries streamed by the server after the ALLOWED byte.
 ///
 /// Reads until the remote sender closes the stream, returning all decoded entries.
 ///

--- a/src/core/ticket.rs
+++ b/src/core/ticket.rs
@@ -28,7 +28,7 @@ pub struct ShareTicket {
 }
 
 impl ShareTicket {
-    /// Create a ticket for a single raw blob (`BlobFormat::Raw`).
+    /// Creates a ticket for a single raw blob (`BlobFormat::Raw`).
     pub fn new(addr: EndpointAddr, hash: Hash, name: Option<String>) -> Self {
         ShareTicket {
             addr,
@@ -38,7 +38,7 @@ impl ShareTicket {
         }
     }
 
-    /// Create a ticket for a directory / collection (`BlobFormat::HashSeq`).
+    /// Creates a ticket for a directory / collection (`BlobFormat::HashSeq`).
     pub fn new_collection(addr: EndpointAddr, hash: Hash, name: Option<String>) -> Self {
         ShareTicket {
             addr,
@@ -48,7 +48,7 @@ impl ShareTicket {
         }
     }
 
-    /// Create a ticket with an explicit `format`.
+    /// Creates a ticket with an explicit `format`.
     pub fn from_format(
         addr: EndpointAddr,
         hash: Hash,
@@ -85,7 +85,7 @@ impl ShareTicket {
         self.addr.id
     }
 
-    /// Encode the ticket as a `rdrop://` URI.
+    /// Encodes the ticket as a `rdrop://` URI.
     ///
     /// The URI is base32-encoded JSON and can be decoded with [`ShareTicket::from_uri`].
     ///
@@ -104,7 +104,7 @@ impl ShareTicket {
         Ok(format!("rdrop://{encoded}"))
     }
 
-    /// Decode a `rdrop://` URI produced by [`ShareTicket::to_uri`].
+    /// Decodes a `rdrop://` URI produced by [`ShareTicket::to_uri`].
     ///
     /// # Errors
     ///

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -30,7 +30,7 @@ pub struct DaemonClient {
 }
 
 impl DaemonClient {
-    /// Create a client that connects to the daemon on `127.0.0.1:port`.
+    /// Creates a client that connects to the daemon on `127.0.0.1:port`.
     pub fn new(port: u16) -> Self {
         Self {
             addr: SocketAddr::from(([127, 0, 0, 1], port)),
@@ -42,7 +42,7 @@ impl DaemonClient {
         TcpStream::connect(self.addr).await.is_ok()
     }
 
-    /// Send an operation to the daemon and call `on_event` for each event
+    /// Sends an operation to the daemon and calls `on_event` for each event
     /// received until [`EventKind::Done`] or [`EventKind::Error`] for this
     /// request's `req_id`.
     ///

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -29,11 +29,11 @@ pub struct Request {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "op", rename_all = "snake_case")]
 pub enum Op {
-    /// Return this node's [`EndpointId`] as a hex string.
+    /// Returns this node's [`EndpointId`] as a hex string.
     ///
     /// [`EndpointId`]: iroh::EndpointId
     NodeId,
-    /// Import a file or directory and tag it with the given rings.
+    /// Imports a file or directory and tags it with the given rings.
     Import {
         /// Path to the file or directory to import.
         path: PathBuf,
@@ -42,19 +42,19 @@ pub enum Op {
         /// Tag the blob as publicly accessible, overriding `rings`.
         open: bool,
     },
-    /// List all blobs in the local store.
+    /// Lists all blobs in the local store.
     BlobList {
         /// Optional filter by this peer-id.
         peer: Option<String>,
         /// Optional filter by a ring name.
         rings: Option<Vec<String>>,
     },
-    /// Remove a blob from the local store. `target` is a filename or hex hash.
+    /// Removes a blob from the local store. `target` is a filename or hex hash.
     BlobRemove {
         /// File path or BLAKE3 hex hash identifying the blob to remove.
         target: String,
     },
-    /// Tag a blob with the given rings (or the open ring). `target` is a filename or hex hash.
+    /// Tags a blob with the given rings (or the open ring). `target` is a filename or hex hash.
     Tag {
         /// File path or BLAKE3 hex hash identifying the blob to tag.
         target: String,
@@ -63,7 +63,7 @@ pub enum Op {
         /// Tag the blob as publicly accessible, overriding `rings`.
         open: bool,
     },
-    /// Remove ring associations from a blob. `target` is a filename or hex hash.
+    /// Removes ring associations from a blob. `target` is a filename or hex hash.
     ///
     /// Exactly one of `rings` (non-empty), `open`, or `all` must be set.
     Untag {
@@ -76,14 +76,14 @@ pub enum Op {
         /// Remove every ring association, making the blob inaccessible.
         all: bool,
     },
-    /// Create a new ring with the given name.
+    /// Creates a new ring with the given name.
     RingNew {
         /// Name for the new ring (e.g. `"friends"` or `"work-team"`).
         name: String,
     },
-    /// List all rings.
+    /// Lists all rings.
     RingList,
-    /// Add `peer` to `ring`.
+    /// Adds `peer` to `ring`.
     ///
     /// If the peer is not yet in the peer store it is automatically registered
     /// there with no nickname. Use [`Op::PeerAdd`] with `--nickname` to set one.
@@ -95,7 +95,7 @@ pub enum Op {
         /// [`EndpointId`]: iroh::EndpointId
         peer: String,
     },
-    /// Remove `peer` from `ring`.
+    /// Removes `peer` from `ring`.
     RingRemove {
         /// Name of the ring to remove the peer from.
         ring: String,
@@ -104,12 +104,12 @@ pub enum Op {
         /// [`EndpointId`]: iroh::EndpointId
         peer: String,
     },
-    /// List all members of `ring`.
+    /// Lists all members of `ring`.
     RingMembers {
         /// Name of the ring whose membership to list.
         ring: String,
     },
-    /// Download the blob described by `ticket` and export it to `dest`.
+    /// Downloads the blob described by `ticket` and exports it to `dest`.
     Receive {
         /// URI-encoded [`ShareTicket`] produced by `rdrop import` or `rdrop blob list`.
         ///
@@ -120,7 +120,7 @@ pub enum Op {
         /// Overwrite an existing destination without prompting.
         force_overwrite: bool,
     },
-    /// Grant `privilege` to `peer`.
+    /// Grants `privilege` to `peer`.
     ///
     /// `peer` is a base32-encoded [`EndpointId`]; `privilege` is the canonical
     /// privilege name (e.g. `"blob-list"`).
@@ -134,7 +134,7 @@ pub enum Op {
         /// Privilege to grant (e.g. `"blob-list"`).
         privilege: String,
     },
-    /// Revoke `privilege` from `peer`.
+    /// Revokes `privilege` from `peer`.
     ///
     /// `peer` is a base32-encoded [`EndpointId`]; `privilege` is the canonical
     /// privilege name (e.g. `"blob-list"`).
@@ -148,7 +148,7 @@ pub enum Op {
         /// Privilege to revoke (e.g. `"blob-list"`).
         privilege: String,
     },
-    /// List current grants as `privilege peer_id` pairs, one per [`EventKind::Line`].
+    /// Lists current grants as `privilege peer_id` pairs, one per [`EventKind::Line`].
     ///
     /// Both filters are optional; omitting them returns all grants.
     Grants {
@@ -161,7 +161,7 @@ pub enum Op {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         privilege: Option<String>,
     },
-    /// Fetch the blob catalog from a remote node.
+    /// Fetches the blob catalog from a remote node.
     ///
     /// The remote node must have granted `BlobList` privilege to the local
     /// node's identity. Entries visible via ring membership are streamed back
@@ -176,7 +176,7 @@ pub enum Op {
         /// [`EndpointId`]: iroh::EndpointId
         peer: String,
     },
-    /// Add `peer` to the peer store, optionally with a nickname.
+    /// Adds `peer` to the peer store, optionally with a nickname.
     ///
     /// Idempotent: if the peer is already in the store the nickname is updated.
     /// `peer` is a base32-encoded [`EndpointId`].
@@ -191,9 +191,9 @@ pub enum Op {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         nickname: Option<String>,
     },
-    /// List all peers in the local peer store with their nicknames.
+    /// Lists all peers in the local peer store with their nicknames.
     PeerList,
-    /// Remove a peer from the local peer store and from all rings.
+    /// Removes a peer from the local peer store and from all rings.
     ///
     /// Errors if the peer is not in the store. `peer` is a base32-encoded
     /// [`EndpointId`].
@@ -205,7 +205,7 @@ pub enum Op {
         /// [`EndpointId`]: iroh::EndpointId
         peer: String,
     },
-    /// Gracefully stop the daemon after draining in-flight requests.
+    /// Gracefully stops the daemon after draining in-flight requests.
     Shutdown,
 }
 
@@ -249,7 +249,7 @@ pub enum EventKind {
 }
 
 impl Event {
-    /// Construct a [`EventKind::Line`] event carrying a text message.
+    /// Constructs a [`EventKind::Line`] event carrying a text message.
     pub fn line(req_id: Uuid, text: impl Into<String>) -> Self {
         Self {
             req_id,
@@ -257,12 +257,12 @@ impl Event {
         }
     }
 
-    /// Construct a blank [`EventKind::Line`] event — renders as an empty line in the console.
+    /// Constructs a blank [`EventKind::Line`] event — renders as an empty line in the console.
     pub fn blank(req_id: Uuid) -> Self {
         Self::line(req_id, "")
     }
 
-    /// Construct a [`EventKind::Progress`] event with byte counts.
+    /// Constructs a [`EventKind::Progress`] event with byte counts.
     pub fn progress(req_id: Uuid, done: u64, total: u64) -> Self {
         Self {
             req_id,
@@ -270,7 +270,7 @@ impl Event {
         }
     }
 
-    /// Construct a [`EventKind::Done`] event signalling successful completion.
+    /// Constructs a [`EventKind::Done`] event signalling successful completion.
     pub fn done(req_id: Uuid) -> Self {
         Self {
             req_id,
@@ -278,7 +278,7 @@ impl Event {
         }
     }
 
-    /// Construct an [`EventKind::Error`] event carrying a human-readable message.
+    /// Constructs an [`EventKind::Error`] event carrying a human-readable message.
     pub fn error(req_id: Uuid, message: impl Into<String>) -> Self {
         Self {
             req_id,

--- a/src/daemon/server/handlers/peer.rs
+++ b/src/daemon/server/handlers/peer.rs
@@ -58,7 +58,7 @@ pub(crate) fn peer_list_lines(peer_store: &PeerStore) -> Result<Vec<String>> {
     Ok(out)
 }
 
-/// Remove a peer from the store, all rings, and all catalog grants.
+/// Removes a peer from the store, all rings, and all catalog grants.
 ///
 /// Errors if the peer is not in the store, consistent with how `ring remove`
 /// and `grant remove` behave.

--- a/src/daemon/server/handlers/ring.rs
+++ b/src/daemon/server/handlers/ring.rs
@@ -38,7 +38,7 @@ pub(crate) fn ring_list_lines(registry: &impl Registry) -> Result<Vec<String>> {
     Ok(out)
 }
 
-/// Add `peer` to `ring` and ensure the peer exists in the peer store.
+/// Adds `peer` to `ring` and ensures the peer exists in the peer store.
 ///
 /// Nicknames are managed independently via [`Op::PeerNick`] / [`Op::PeerAdd`].
 /// The iroh-rings registry is always called with `label: None`.

--- a/src/daemon/server/handlers/tag.rs
+++ b/src/daemon/server/handlers/tag.rs
@@ -53,7 +53,7 @@ pub(crate) async fn handle_tag<R: Registry + Clone + Send + Sync + 'static>(
     Ok(())
 }
 
-/// Remove ring associations from a blob.
+/// Removes ring associations from a blob.
 ///
 /// - `all`: clear every ring association.
 /// - `open`: remove only the open-ring association, keeping named rings.

--- a/src/daemon/server/mod.rs
+++ b/src/daemon/server/mod.rs
@@ -45,7 +45,7 @@ pub struct DaemonServer<R> {
 }
 
 impl<R: Registry + Clone + Send + Sync + 'static> DaemonServer<R> {
-    /// Bind the daemon to `127.0.0.1:port` (use `0` to let the OS pick a port).
+    /// Binds the daemon to `127.0.0.1:port` (use `0` to let the OS pick a port).
     ///
     /// # Errors
     ///
@@ -72,7 +72,7 @@ impl<R: Registry + Clone + Send + Sync + 'static> DaemonServer<R> {
             .port()
     }
 
-    /// Run the server event loop until an [`Op::Shutdown`] request is received.
+    /// Runs the server event loop until an [`Op::Shutdown`] request is received.
     ///
     /// Accepts connections, dispatches requests, and on shutdown drains
     /// in-flight tasks (up to 30 s) before calling [`Node::shutdown`].
@@ -175,7 +175,7 @@ async fn handle_connection<R: Registry + Clone + Send + Sync + 'static>(
     Ok(())
 }
 
-/// Write one event to the TCP stream. Returns `false` if the connection should
+/// Writes one event to the TCP stream. Returns `false` if the connection should
 /// be closed — either because the event could not be serialized (logged as an
 /// error) or because the write itself failed (client disconnected, not logged).
 async fn emit(writer: &mut (impl AsyncWriteExt + Unpin), event: &Event) -> bool {

--- a/src/local_store.rs
+++ b/src/local_store.rs
@@ -25,7 +25,7 @@ pub(crate) struct LocalStore {
 }
 
 impl LocalStore {
-    /// Open (or create) `local.redb` in `data_dir`, running migration from the
+    /// Opens (or creates) `local.redb` in `data_dir`, running migration from the
     /// old separate files if needed.
     ///
     /// # Errors
@@ -49,7 +49,7 @@ impl LocalStore {
 const GRANTS: TableDefinition<'_, &[u8], ()> = TableDefinition::new("grants");
 const PEERS: TableDefinition<'_, &[u8], &str> = TableDefinition::new("peers");
 
-/// Migrate `grants.redb` and `peers.redb` into `local.redb` when needed.
+/// Migrates `grants.redb` and `peers.redb` into `local.redb` when needed.
 ///
 /// Exits immediately when `local.redb` already exists or neither old file is
 /// present (fresh install). Otherwise:
@@ -166,7 +166,7 @@ fn copy_peers(dst: &Database, src_path: &Path) -> Result<()> {
     Ok(())
 }
 
-/// Backfill the PEERS table with members found in named rings in `registry.redb`.
+/// Backfills the PEERS table with members found in named rings in `registry.redb`.
 ///
 /// Any peer that is already present in PEERS (i.e. was in `peers.redb`) is
 /// left untouched — existing nicknames are preserved. Only peers absent from

--- a/src/util.rs
+++ b/src/util.rs
@@ -16,7 +16,7 @@ pub fn default_data_dir() -> PathBuf {
         .join(".ringdrop")
 }
 
-/// Parse an [`EndpointId`] from its base32 string representation.
+/// Parses an [`EndpointId`] from its base32 string representation.
 ///
 /// # Errors
 ///
@@ -28,7 +28,7 @@ pub fn parse_peer_id(s: &str) -> Result<EndpointId> {
         .map_err(|e| anyhow::anyhow!("invalid peer id: {e}"))
 }
 
-/// Strip direct IP addresses from an endpoint address, keeping only relay URLs and the node ID.
+/// Strips direct IP addresses from an endpoint address, keeping only relay URLs and the node ID.
 ///
 /// Tickets and catalog entries use relay-only addresses so they remain valid
 /// across daemon restarts and IP changes. iroh still negotiates a direct
@@ -41,7 +41,7 @@ pub(crate) fn relay_only_addr(full: EndpointAddr) -> EndpointAddr {
         })
 }
 
-/// Format a peer ID with an optional nickname into a display string.
+/// Formats a peer ID with an optional nickname into a display string.
 ///
 /// Returns `"peer_id  (nickname)"` when a nickname is provided, or the peer ID
 /// alone when `nick` is `None`.
@@ -52,7 +52,7 @@ pub(crate) fn format_peer_entry(peer: &EndpointId, nick: Option<&str>) -> String
     }
 }
 
-/// Format a peer for display, resolving its nickname from the peer store.
+/// Formats a peer for display, resolving its nickname from the peer store.
 ///
 /// Delegates to [`format_peer_entry`] after looking up the nickname. Silently
 /// falls back to the raw ID on store read errors.
@@ -61,7 +61,7 @@ pub(crate) fn display_peer(peer: &EndpointId, store: &PeerStore) -> String {
     format_peer_entry(peer, nick.as_deref())
 }
 
-/// Parse a BLAKE3 [`Hash`] from its hex string representation.
+/// Parses a BLAKE3 [`Hash`] from its hex string representation.
 ///
 /// # Errors
 ///


### PR DESCRIPTION
Closes #18

This change makes possible to set a custom iroh relay server in `config.json`.
The default is using n0's infrastructure.