### PR TITLE
Make the daemon IPC protocol structured

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3372,7 +3372,7 @@ dependencies = [
 
 [[package]]
 name = "ringdrop"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bao-tree",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ resolver = "2"
 
 [package]
 name = "ringdrop"
-version = "0.11.1"
+version = "0.12.0"
 edition = "2021"
 authors = ["Enrico Fusto"]
 license = "MIT"

--- a/src/cli/command/receive.rs
+++ b/src/cli/command/receive.rs
@@ -76,6 +76,7 @@ pub(crate) async fn run(
                     pb.finish_and_clear();
                     error_msg = Some(message);
                 }
+                EventKind::Record { .. } => {}
             },
         )
         .await?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -145,4 +145,23 @@ mod tests {
             "https://relay.example.com/"
         );
     }
+
+    #[test]
+    fn public_id_matches_secret_key() {
+        let dir = tmpdir();
+        let cfg = Config::load_or_create(dir.path()).unwrap();
+        assert_eq!(cfg.public_id(), cfg.secret_key.public());
+    }
+
+    #[test]
+    fn config_with_unknown_fields_is_accepted() {
+        let dir = tmpdir();
+        let key = iroh::SecretKey::generate();
+        let json = serde_json::json!({
+            "secret_key": key,
+            "unknown_future_field": "some_value",
+        });
+        std::fs::write(dir.path().join("config.json"), json.to_string()).unwrap();
+        assert!(Config::load_or_create(dir.path()).is_ok());
+    }
 }

--- a/src/core/protocol/catalog.rs
+++ b/src/core/protocol/catalog.rs
@@ -56,7 +56,7 @@ pub(crate) const DENIED: u8 = 0x00;
 /// command-specific response payload.
 pub(crate) const ALLOWED: u8 = 0x01;
 
-/// A single entry returned by a [`BLOB_LIST`] command.
+/// A single entry returned by a `BLOB_LIST` command.
 #[derive(Debug, Clone)]
 pub struct CatalogEntry {
     /// BLAKE3 root hash of the blob or collection.

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -94,7 +94,7 @@ impl DaemonClient {
         self.send(op, |event| match event.kind {
             EventKind::Line { text } => println!("{text}"),
             EventKind::Error { message } => err = Some(message),
-            EventKind::Done | EventKind::Progress { .. } => {}
+            EventKind::Done | EventKind::Progress { .. } | EventKind::Record { .. } => {}
         })
         .await?;
         if let Some(msg) = err {

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -663,4 +663,25 @@ mod tests {
             serde_json::from_str(&serde_json::to_string(&original).unwrap()).unwrap();
         assert_eq!(parsed, original);
     }
+
+    #[test]
+    fn event_blank_produces_empty_text() {
+        let id = Uuid::new_v4();
+        let event = Event::blank(id);
+        assert_eq!(
+            event.kind,
+            EventKind::Line {
+                text: String::new()
+            }
+        );
+    }
+
+    #[test]
+    fn event_record_round_trips_with_non_object_json_value() {
+        let id = Uuid::new_v4();
+        let original = Event::record(id, serde_json::json!([1, 2, 3]));
+        let parsed: Event =
+            serde_json::from_str(&serde_json::to_string(&original).unwrap()).unwrap();
+        assert_eq!(parsed, original);
+    }
 }

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -246,6 +246,15 @@ pub enum EventKind {
         /// Human-readable description of the failure.
         message: String,
     },
+    /// Structured data record for machine consumers (e.g. a GUI).
+    ///
+    /// Emitted alongside or instead of `Line` events by ops that return lists.
+    /// The CLI ignores this variant; the GUI uses it exclusively.
+    Record {
+        /// JSON-encoded payload. The shape depends on the originating `Op` —
+        /// see each handler's documentation for the field names.
+        value: serde_json::Value,
+    },
 }
 
 impl Event {
@@ -285,6 +294,14 @@ impl Event {
             kind: EventKind::Error {
                 message: message.into(),
             },
+        }
+    }
+
+    /// Constructs an [`EventKind::Record`] event carrying a structured JSON value.
+    pub fn record(req_id: Uuid, value: serde_json::Value) -> Self {
+        Self {
+            req_id,
+            kind: EventKind::Record { value },
         }
     }
 }
@@ -620,5 +637,30 @@ mod tests {
                 nickname: None,
             }
         );
+    }
+
+    #[test]
+    fn event_record_serializes_correctly() {
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        let value = serde_json::json!({"hash": "abc123", "name": "file.txt"});
+        let event = Event::record(id, value);
+        let json = serde_json::to_string(&event).unwrap();
+        // Must carry the "type":"record" tag and the value fields.
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed["type"], "record");
+        assert_eq!(parsed["value"]["hash"], "abc123");
+        assert_eq!(parsed["value"]["name"], "file.txt");
+        assert_eq!(parsed["req_id"], "550e8400-e29b-41d4-a716-446655440000");
+    }
+
+    #[test]
+    fn event_record_round_trips_through_json() {
+        let original = Event::record(
+            Uuid::new_v4(),
+            serde_json::json!({"peer_id": "deadbeef", "rings": ["friends", "work"]}),
+        );
+        let parsed: Event =
+            serde_json::from_str(&serde_json::to_string(&original).unwrap()).unwrap();
+        assert_eq!(parsed, original);
     }
 }

--- a/src/daemon/server/handlers/blob.rs
+++ b/src/daemon/server/handlers/blob.rs
@@ -75,7 +75,7 @@ pub(crate) async fn handle_import<R: Registry + Clone + Send + Sync + 'static>(
     }
 
     let display_name = path.file_name().map(|n| n.to_string_lossy().into_owned());
-    let ticket = node.make_ticket(hash, format, display_name);
+    let ticket = node.make_ticket(hash, format, display_name.clone());
     let ticket_str = ticket.to_uri()?;
 
     send(tx, Event::blank(req_id)).await;
@@ -86,6 +86,24 @@ pub(crate) async fn handle_import<R: Registry + Clone + Send + Sync + 'static>(
     send(
         tx,
         Event::line(req_id, format!("  rdrop receive {ticket_str}")),
+    )
+    .await;
+    let format_str = if format == iroh_blobs::BlobFormat::HashSeq {
+        "hash_seq"
+    } else {
+        "raw"
+    };
+    send(
+        tx,
+        Event::record(
+            req_id,
+            serde_json::json!({
+                "hash": hash.to_string(),
+                "format": format_str,
+                "name": display_name.as_deref().unwrap_or(""),
+                "ticket": ticket_str,
+            }),
+        ),
     )
     .await;
     send(tx, Event::done(req_id)).await;
@@ -133,6 +151,20 @@ pub(crate) async fn handle_blob_list<R: Registry + Clone + Send + Sync + 'static
                 .await;
             }
             send(tx, Event::line(req_id, format!("    ticket: {ticket_str}"))).await;
+            let ring_names: Vec<_> = rings.iter().map(|(r, _)| r.as_str().to_owned()).collect();
+            send(
+                tx,
+                Event::record(
+                    req_id,
+                    serde_json::json!({
+                        "hash": hash.to_string(),
+                        "name": name,
+                        "rings": ring_names,
+                        "ticket": ticket_str,
+                    }),
+                ),
+            )
+            .await;
         }
     }
     send(tx, Event::done(req_id)).await;
@@ -152,6 +184,11 @@ pub(crate) async fn handle_blob_remove<R: Registry + Clone + Send + Sync + 'stat
     send(
         tx,
         Event::line(req_id, "Disk space will be reclaimed on the next GC cycle."),
+    )
+    .await;
+    send(
+        tx,
+        Event::record(req_id, serde_json::json!({ "hash": hash.to_string() })),
     )
     .await;
     send(tx, Event::done(req_id)).await;

--- a/src/daemon/server/handlers/grant.rs
+++ b/src/daemon/server/handlers/grant.rs
@@ -53,9 +53,40 @@ pub(crate) async fn handle_grants<R: Registry + Clone + Send + Sync + 'static>(
     peer: Option<String>,
     privilege: Option<String>,
 ) -> Result<()> {
+    let peer_id_filter = peer
+        .as_deref()
+        .map(crate::util::parse_peer_id)
+        .transpose()?;
+    let priv_filter = privilege
+        .as_deref()
+        .map(crate::core::grants::Privilege::try_from)
+        .transpose()?;
+
+    let matching: Vec<_> = node
+        .grants
+        .list()?
+        .into_iter()
+        .filter(|(priv_, peer)| {
+            peer_id_filter.is_none_or(|f| *peer == f) && priv_filter.is_none_or(|f| *priv_ == f)
+        })
+        .collect();
+
     let lines = filtered_grant_lines(&node.grants, peer.as_deref(), privilege.as_deref())?;
     for line in lines {
         send(tx, Event::line(req_id, line)).await;
+    }
+    for (priv_, peer_id) in &matching {
+        send(
+            tx,
+            Event::record(
+                req_id,
+                serde_json::json!({
+                    "privilege": priv_.as_str(),
+                    "peer_id": peer_id.to_string(),
+                }),
+            ),
+        )
+        .await;
     }
     send(tx, Event::done(req_id)).await;
     Ok(())

--- a/src/daemon/server/handlers/remote.rs
+++ b/src/daemon/server/handlers/remote.rs
@@ -44,6 +44,18 @@ pub(crate) async fn handle_remote_blob_list<R: Registry + Clone + Send + Sync + 
             )
             .await;
             send(tx, Event::line(req_id, format!("    ticket: {ticket_str}"))).await;
+            send(
+                tx,
+                Event::record(
+                    req_id,
+                    serde_json::json!({
+                        "hash": entry.hash.to_string(),
+                        "name": entry.name,
+                        "ticket": ticket_str,
+                    }),
+                ),
+            )
+            .await;
         }
     }
     send(tx, Event::done(req_id)).await;

--- a/src/daemon/server/handlers/ring.rs
+++ b/src/daemon/server/handlers/ring.rs
@@ -205,4 +205,92 @@ mod tests {
         let lines = ring_members_lines(&registry, &peers, "friends").unwrap();
         assert!(lines.iter().any(|l| l.contains(&peer_id.to_string())));
     }
+
+    #[test]
+    fn ring_new_creates_ring_and_returns_confirmation() {
+        let dir = TempDir::new().unwrap();
+        let (registry, _, _) = setup(&dir);
+
+        let lines = ring_new_lines(&registry, "alpha").unwrap();
+        assert_eq!(lines.len(), 2);
+        assert!(lines[0].contains("Ring created: alpha"));
+    }
+
+    #[test]
+    fn ring_list_shows_open_ring_with_public_description() {
+        let dir = TempDir::new().unwrap();
+        let (registry, _, _) = setup(&dir);
+
+        let lines = ring_list_lines(&registry).unwrap();
+        assert!(lines
+            .iter()
+            .any(|l| l.contains(OPEN_RING_NAME) && l.contains("publicly accessible")));
+    }
+
+    #[test]
+    fn ring_list_shows_named_ring_with_member_count() {
+        let dir = TempDir::new().unwrap();
+        let (registry, peers, public_id) = setup(&dir);
+        registry.create_ring("work").unwrap();
+        let (_, peer_str) = new_peer();
+        ring_add_lines(&registry, &peers, public_id, "work", &peer_str).unwrap();
+
+        let lines = ring_list_lines(&registry).unwrap();
+        assert!(lines
+            .iter()
+            .any(|l| l.contains("work") && l.contains("1 members")));
+    }
+
+    #[test]
+    fn ring_remove_removes_peer_from_ring() {
+        let dir = TempDir::new().unwrap();
+        let (registry, peers, public_id) = setup(&dir);
+        registry.create_ring("friends").unwrap();
+        let (_, peer_str) = new_peer();
+        ring_add_lines(&registry, &peers, public_id, "friends", &peer_str).unwrap();
+
+        let lines = ring_remove_lines(&registry, "friends", &peer_str).unwrap();
+        assert!(lines.iter().any(|l| l.contains("Removed")));
+        assert_eq!(registry.list_ring_peers("friends").unwrap().len(), 0);
+    }
+
+    #[test]
+    fn ring_remove_from_open_ring_returns_no_op_message() {
+        let dir = TempDir::new().unwrap();
+        let (registry, _, _) = setup(&dir);
+        let (_, peer_str) = new_peer();
+
+        let lines = ring_remove_lines(&registry, OPEN_RING_NAME, &peer_str).unwrap();
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("no membership list"));
+    }
+
+    #[test]
+    fn ring_remove_with_invalid_peer_string_returns_error() {
+        let dir = TempDir::new().unwrap();
+        let (registry, _, _) = setup(&dir);
+
+        let err = ring_remove_lines(&registry, "friends", "not-a-peer-id").unwrap_err();
+        assert!(err.to_string().contains("invalid peer id"));
+    }
+
+    #[test]
+    fn ring_members_on_empty_ring_returns_no_members_message() {
+        let dir = TempDir::new().unwrap();
+        let (registry, peers, _) = setup(&dir);
+        registry.create_ring("empty-ring").unwrap();
+
+        let lines = ring_members_lines(&registry, &peers, "empty-ring").unwrap();
+        assert!(lines.iter().any(|l| l.contains("no members")));
+    }
+
+    #[test]
+    fn ring_members_on_open_ring_returns_public_description() {
+        let dir = TempDir::new().unwrap();
+        let (registry, peers, _) = setup(&dir);
+
+        let lines = ring_members_lines(&registry, &peers, OPEN_RING_NAME).unwrap();
+        assert_eq!(lines.len(), 1);
+        assert!(lines[0].contains("public"));
+    }
 }

--- a/src/daemon/server/mod.rs
+++ b/src/daemon/server/mod.rs
@@ -221,8 +221,13 @@ async fn handle_op<R: Registry + Clone + Send + Sync + 'static>(
 ) -> Result<()> {
     match op {
         Op::NodeId => {
+            let peer_id = node.endpoint.id();
+            let _ = tx.send(Event::line(req_id, peer_id.to_string())).await;
             let _ = tx
-                .send(Event::line(req_id, node.endpoint.id().to_string()))
+                .send(Event::record(
+                    req_id,
+                    serde_json::json!({ "peer_id": peer_id.to_string() }),
+                ))
                 .await;
             let _ = tx.send(Event::done(req_id)).await;
         }
@@ -253,11 +258,25 @@ async fn handle_op<R: Registry + Clone + Send + Sync + 'static>(
         Op::RingNew { name } => {
             let lines = handlers::ring::ring_new_lines(&node.registry, &name)?;
             send_lines(tx, req_id, &lines).await;
+            let _ = tx
+                .send(Event::record(req_id, serde_json::json!({ "name": name })))
+                .await;
             let _ = tx.send(Event::done(req_id)).await;
         }
         Op::RingList => {
             let lines = handlers::ring::ring_list_lines(&node.registry)?;
             send_lines(tx, req_id, &lines).await;
+            for ring in node.registry.list_rings()? {
+                let _ = tx
+                    .send(Event::record(
+                        req_id,
+                        serde_json::json!({
+                            "name": ring.as_str(),
+                            "open": ring.is_open(),
+                        }),
+                    ))
+                    .await;
+            }
             let _ = tx.send(Event::done(req_id)).await;
         }
         Op::RingAdd { ring, peer } => {
@@ -279,16 +298,50 @@ async fn handle_op<R: Registry + Clone + Send + Sync + 'static>(
         Op::RingMembers { ring } => {
             let lines = handlers::ring::ring_members_lines(&node.registry, &node.peers, &ring)?;
             send_lines(tx, req_id, &lines).await;
+            if ring != iroh_rings::OPEN_RING_NAME {
+                for (peer_id, _label) in node.registry.list_ring_peers(&ring)? {
+                    let nickname = node.peers.get(&peer_id).ok().flatten().flatten();
+                    let _ = tx
+                        .send(Event::record(
+                            req_id,
+                            serde_json::json!({
+                                "peer_id": peer_id.to_string(),
+                                "nickname": nickname,
+                            }),
+                        ))
+                        .await;
+                }
+            }
             let _ = tx.send(Event::done(req_id)).await;
         }
         Op::PeerAdd { peer, nickname } => {
             let lines = handlers::peer::peer_add_lines(&node.peers, &peer, nickname.as_deref())?;
             send_lines(tx, req_id, &lines).await;
+            let _ = tx
+                .send(Event::record(
+                    req_id,
+                    serde_json::json!({
+                        "peer_id": peer,
+                        "nickname": nickname,
+                    }),
+                ))
+                .await;
             let _ = tx.send(Event::done(req_id)).await;
         }
         Op::PeerList => {
             let lines = handlers::peer::peer_list_lines(&node.peers)?;
             send_lines(tx, req_id, &lines).await;
+            for (peer_id, nick) in node.peers.list()? {
+                let _ = tx
+                    .send(Event::record(
+                        req_id,
+                        serde_json::json!({
+                            "peer_id": peer_id.to_string(),
+                            "nickname": nick,
+                        }),
+                    ))
+                    .await;
+            }
             let _ = tx.send(Event::done(req_id)).await;
         }
         Op::PeerRemove { peer } => {

--- a/src/util.rs
+++ b/src/util.rs
@@ -113,4 +113,30 @@ mod tests {
         let result = relay_only_addr(addr);
         assert_eq!(result.id, id);
     }
+
+    #[test]
+    fn relay_only_addr_preserves_relay_url() {
+        use iroh::RelayUrl;
+        let id = SecretKey::generate().public();
+        let url: RelayUrl = "https://relay.example.com".parse().unwrap();
+        let addr = EndpointAddr::new(id).with_relay_url(url.clone());
+        let result = relay_only_addr(addr);
+        assert_eq!(result.id, id);
+        assert!(result.relay_urls().any(|u| u == &url));
+    }
+
+    #[test]
+    fn format_peer_entry_without_nickname_returns_raw_id() {
+        let id = SecretKey::generate().public();
+        let result = format_peer_entry(&id, None);
+        assert_eq!(result, id.to_string());
+    }
+
+    #[test]
+    fn format_peer_entry_with_nickname_includes_nickname_in_parens() {
+        let id = SecretKey::generate().public();
+        let result = format_peer_entry(&id, Some("alice"));
+        assert!(result.contains(&id.to_string()));
+        assert!(result.contains("(alice)"));
+    }
 }


### PR DESCRIPTION
To open the door to a GUI client run in the same host as the daemon, we need the IPC to be easily parsable and destructured to access daemon feedbacks.

This PR adds a `Record` event to the IPC, making it coexist with the cli-frugal `Line` event, which is cli-sufficient.
