### PR TITLE
feat(blobs): added rich information progress via new ProgressEvent

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -120,7 +120,7 @@ Offer blob lifecycle management.
 | Command | Description |
 |---|---|
 | `rdrop blob import <filename>` | Import a file or directory |
-| `rdrop blob list` | List all local blobs with ring associations and tickets |
+| `rdrop blob list` | List all local blobs with kind, size and ring associations and tickets |
 | `rdrop blob remove <filename\|hash>` | Remove a blob and all its ring associations |
 | `rdrop blob attach <filename\|hash> <ring>...` | Attach a blob to one or more rings |
 | `rdrop blob detach <filename\|hash> <ring>...` | Detach a blob from one or more rings |

--- a/src/cli/command/receive.rs
+++ b/src/cli/command/receive.rs
@@ -54,6 +54,9 @@ pub(crate) async fn run(
     );
 
     let mut error_msg: Option<String> = None;
+    // (file_index, file_total, file_name) of the file currently downloading.
+    let mut current_file: Option<(usize, usize, String)> = None;
+
     client
         .send(
             Op::Receive {
@@ -76,14 +79,29 @@ pub(crate) async fn run(
                     done,
                     total,
                 } => {
-                    pb.set_message(format!(" [{file_index}/{file_total}] {file_name}"));
+                    let is_new_file = current_file
+                        .as_ref()
+                        .map_or(true, |(fi, _, _)| *fi != file_index);
+                    if is_new_file {
+                        // Print a static completion line for the file that just finished.
+                        if let Some((pfi, pft, pfname)) = current_file.take() {
+                            pb.println(format!("  \u{2713} [{pfi}/{pft}] {pfname}"));
+                        }
+                        current_file = Some((file_index, file_total, file_name.clone()));
+                        pb.set_message(format!(" [{file_index}/{file_total}] {file_name}"));
+                    }
                     pb.set_length(total);
                     pb.set_position(done);
                 }
                 EventKind::Done => {
+                    // Print completion line for the last file of a directory transfer.
+                    if let Some((fi, ft, fname)) = current_file.take() {
+                        pb.println(format!("  \u{2713} [{fi}/{ft}] {fname}"));
+                    }
                     pb.finish_and_clear();
                 }
                 EventKind::Error { message } => {
+                    current_file = None;
                     pb.finish_and_clear();
                     error_msg = Some(message);
                 }

--- a/src/cli/command/receive.rs
+++ b/src/cli/command/receive.rs
@@ -81,7 +81,7 @@ pub(crate) async fn run(
                 } => {
                     let is_new_file = current_file
                         .as_ref()
-                        .map_or(true, |(fi, _, _)| *fi != file_index);
+                        .is_none_or(|(fi, _, _)| *fi != file_index);
                     if is_new_file {
                         // Print a static completion line for the file that just finished.
                         if let Some((pfi, pft, pfname)) = current_file.take() {

--- a/src/cli/command/receive.rs
+++ b/src/cli/command/receive.rs
@@ -47,7 +47,7 @@ pub(crate) async fn run(
         ProgressStyle::default_bar()
             .template(
                 "{spinner:.green} [{elapsed_precise}] [{bar:40.green/yellow}] \
-                 {bytes}/{total_bytes} ({bytes_per_sec}, {eta})",
+                 {bytes}/{total_bytes} ({bytes_per_sec}, {eta}){msg}",
             )
             .unwrap()
             .progress_chars("█▷ "),
@@ -66,6 +66,17 @@ pub(crate) async fn run(
                     pb.println(text);
                 }
                 EventKind::Progress { done, total } => {
+                    pb.set_length(total);
+                    pb.set_position(done);
+                }
+                EventKind::FileProgress {
+                    file_index,
+                    file_total,
+                    file_name,
+                    done,
+                    total,
+                } => {
+                    pb.set_message(format!(" [{file_index}/{file_total}] {file_name}"));
                     pb.set_length(total);
                     pb.set_position(done);
                 }

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -16,7 +16,8 @@ mod protocol;
 mod ticket;
 
 pub use grants::{GrantStore, Privilege};
-pub use node::Node;
+pub use node::{BlobListEntry, Node};
 pub use peers::PeerStore;
 pub use protocol::catalog::CatalogEntry;
+pub use protocol::ProgressEvent;
 pub use ticket::ShareTicket;

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -368,31 +368,35 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
                     };
                     (None, size)
                 }
-                BlobFormat::HashSeq => {
-                    match Collection::load(hash, &*self.store).await {
-                        Ok(collection) => {
-                            let file_count = collection.iter().count();
-                            let mut size_sum: u64 = 0;
-                            let mut all_complete = true;
-                            for (_, fhash) in collection.iter() {
-                                match self.store.blobs().status(*fhash).await {
-                                    Ok(BlobStatus::Complete { size }) => size_sum += size,
-                                    _ => {
-                                        all_complete = false;
-                                        break;
-                                    }
+                BlobFormat::HashSeq => match Collection::load(hash, &*self.store).await {
+                    Ok(collection) => {
+                        let file_count = collection.iter().count();
+                        let mut size_sum: u64 = 0;
+                        let mut all_complete = true;
+                        for (_, fhash) in collection.iter() {
+                            match self.store.blobs().status(*fhash).await {
+                                Ok(BlobStatus::Complete { size }) => size_sum += size,
+                                _ => {
+                                    all_complete = false;
+                                    break;
                                 }
                             }
-                            (
-                                Some(file_count),
-                                if all_complete { Some(size_sum) } else { None },
-                            )
                         }
-                        Err(_) => (None, None),
+                        (
+                            Some(file_count),
+                            if all_complete { Some(size_sum) } else { None },
+                        )
                     }
-                }
+                    Err(_) => (None, None),
+                },
             };
-            blobs.push(BlobListEntry { hash, format, name, file_count, total_size });
+            blobs.push(BlobListEntry {
+                hash,
+                format,
+                name,
+                file_count,
+                total_size,
+            });
         }
 
         Ok(blobs)

--- a/src/core/node.rs
+++ b/src/core/node.rs
@@ -38,13 +38,29 @@ use super::peers::PeerStore;
 use super::protocol::catalog::{
     decode_entries, CatalogEntry, CatalogHandler, ALLOWED, BLOB_LIST, CATALOG_ALPN,
 };
-use super::protocol::{RingGate, RingReceiver};
+use super::protocol::{ProgressEvent, RingGate, RingReceiver};
 use super::ticket::ShareTicket;
 use crate::config::Config;
 use crate::local_store::LocalStore;
 use iroh_rings::{FsTransfer, Permission, Registry, OPEN_RING_NAME};
 
 use crate::util::parse_peer_id;
+
+/// Metadata about a locally stored blob, returned by [`Node::list_blobs`].
+#[derive(Debug)]
+#[non_exhaustive]
+pub struct BlobListEntry {
+    /// Content-addressed BLAKE3 hash.
+    pub hash: Hash,
+    /// `Raw` for a single file, `HashSeq` for a directory/collection.
+    pub format: BlobFormat,
+    /// Tag name (usually the original filename or directory name).
+    pub name: String,
+    /// Number of files in the collection; `None` for raw blobs.
+    pub file_count: Option<usize>,
+    /// Total content size in bytes; `None` if the store does not yet have all chunks.
+    pub total_size: Option<u64>,
+}
 
 /// A ringdrop P2P node.
 ///
@@ -307,13 +323,13 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
         &self,
         peer: Option<&str>,
         rings: Option<Vec<String>>,
-    ) -> Result<Vec<(Hash, BlobFormat, String)>> {
+    ) -> Result<Vec<BlobListEntry>> {
         let mut stream = self.store.tags().list().await?;
-        let mut blobs = Vec::new();
+        let mut raw: Vec<(Hash, BlobFormat, String)> = Vec::new();
         while let Some(item) = stream.next().await {
             let info = item?;
             let name = String::from_utf8_lossy(&info.name.0).into_owned();
-            blobs.push((info.hash, info.format, name));
+            raw.push((info.hash, info.format, name));
         }
 
         let peer_rings: Option<HashSet<String>> =
@@ -321,24 +337,62 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
         let ring_names: Option<HashSet<String>> = rings.map(|rs| rs.into_iter().collect());
 
         if peer_rings.is_some() || ring_names.is_some() {
-            let mut filtered = Vec::with_capacity(blobs.len());
-            for (hash, format, name) in blobs {
-                let blob_rings = self.registry.list_resource_rings(*hash.as_bytes())?;
+            raw.retain(|(hash, _, _)| {
+                let blob_rings = self
+                    .registry
+                    .list_resource_rings(*hash.as_bytes())
+                    .unwrap_or_default();
                 if let Some(ref rset) = ring_names {
                     if !blob_rings.iter().any(|(r, _)| rset.contains(r.as_str())) {
-                        continue;
+                        return false;
                     }
                 }
                 if let Some(ref pset) = peer_rings {
                     if !blob_rings.iter().any(|(r, perms)| {
                         pset.contains(r.as_str()) && perms.contains(&Permission::Read)
                     }) {
-                        continue;
+                        return false;
                     }
                 }
-                filtered.push((hash, format, name));
-            }
-            blobs = filtered;
+                true
+            });
+        }
+
+        let mut blobs = Vec::with_capacity(raw.len());
+        for (hash, format, name) in raw {
+            let (file_count, total_size) = match format {
+                BlobFormat::Raw => {
+                    let size = match self.store.blobs().status(hash).await {
+                        Ok(BlobStatus::Complete { size }) => Some(size),
+                        _ => None,
+                    };
+                    (None, size)
+                }
+                BlobFormat::HashSeq => {
+                    match Collection::load(hash, &*self.store).await {
+                        Ok(collection) => {
+                            let file_count = collection.iter().count();
+                            let mut size_sum: u64 = 0;
+                            let mut all_complete = true;
+                            for (_, fhash) in collection.iter() {
+                                match self.store.blobs().status(*fhash).await {
+                                    Ok(BlobStatus::Complete { size }) => size_sum += size,
+                                    _ => {
+                                        all_complete = false;
+                                        break;
+                                    }
+                                }
+                            }
+                            (
+                                Some(file_count),
+                                if all_complete { Some(size_sum) } else { None },
+                            )
+                        }
+                        Err(_) => (None, None),
+                    }
+                }
+            };
+            blobs.push(BlobListEntry { hash, format, name, file_count, total_size });
         }
 
         Ok(blobs)
@@ -444,16 +498,20 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
     /// Returns an error if the remote peer denies access, the connection
     /// cannot be established, or the export to disk fails.
     pub async fn download(&self, ticket: &ShareTicket, dest: impl AsRef<Path>) -> Result<()> {
-        self.download_impl(ticket, dest, |_, _| {}).await
+        self.download_impl(ticket, dest, |_| {}).await
     }
 
-    /// Like [`Node::download`], but calls `on_progress(bytes_done, total_bytes)`
+    /// Like [`Node::download`], but calls `on_progress` with a [`ProgressEvent`]
     /// as each chunk is received, suitable for driving a progress bar.
+    ///
+    /// For raw files, only [`ProgressEvent::Bytes`] events are emitted.
+    /// For directory blobs, a [`ProgressEvent::FileStart`] precedes each
+    /// member file's byte events.
     ///
     /// # Errors
     ///
     /// Returns an error under the same conditions as [`Node::download`].
-    pub async fn download_with_progress<F: Fn(u64, u64) + Send + Sync>(
+    pub async fn download_with_progress<F: Fn(ProgressEvent) + Send + Sync>(
         &self,
         ticket: &ShareTicket,
         dest: impl AsRef<Path>,
@@ -462,7 +520,7 @@ impl<R: Registry + Clone + Send + Sync + 'static> Node<R> {
         self.download_impl(ticket, dest, on_progress).await
     }
 
-    async fn download_impl<F: Fn(u64, u64) + Send + Sync>(
+    async fn download_impl<F: Fn(ProgressEvent) + Send + Sync>(
         &self,
         ticket: &ShareTicket,
         dest: impl AsRef<Path>,

--- a/src/core/protocol/mod.rs
+++ b/src/core/protocol/mod.rs
@@ -3,5 +3,5 @@ pub(crate) use iroh_rings::transfers::fs::encode_ranges_wire;
 
 pub(crate) mod catalog;
 mod rings;
-pub(crate) use rings::RingReceiver;
 pub use rings::ProgressEvent;
+pub(crate) use rings::RingReceiver;

--- a/src/core/protocol/mod.rs
+++ b/src/core/protocol/mod.rs
@@ -4,3 +4,4 @@ pub(crate) use iroh_rings::transfers::fs::encode_ranges_wire;
 pub(crate) mod catalog;
 mod rings;
 pub(crate) use rings::RingReceiver;
+pub use rings::ProgressEvent;

--- a/src/core/protocol/rings.rs
+++ b/src/core/protocol/rings.rs
@@ -174,7 +174,10 @@ impl RingReceiver {
             .context("reading bao size header")?;
         let content_size = u64::from_le_bytes(size_buf);
         if let Some(ref p) = on_progress {
-            p(ProgressEvent::Bytes { done: 0, total: content_size });
+            p(ProgressEvent::Bytes {
+                done: 0,
+                total: content_size,
+            });
         }
 
         if let Some(size) = NonZeroU64::new(content_size) {

--- a/src/core/protocol/rings.rs
+++ b/src/core/protocol/rings.rs
@@ -27,6 +27,34 @@ use super::{encode_ranges_wire, encode_request, Status};
 // so the receiver knows the total before any leaf data arrives.
 const BAO_SIZE_HEADER: usize = size_of::<u64>();
 
+/// Progress event emitted by [`Node::download_with_progress`].
+///
+/// Raw-file downloads emit only [`ProgressEvent::Bytes`] events.
+/// Directory (`HashSeq`) downloads additionally emit a
+/// [`ProgressEvent::FileStart`] before each member file begins.
+///
+/// [`Node::download_with_progress`]: crate::core::Node::download_with_progress
+#[derive(Debug)]
+#[non_exhaustive]
+pub enum ProgressEvent {
+    /// A new file within a directory blob is about to be downloaded.
+    FileStart {
+        /// 1-based index of this file in the collection.
+        index: usize,
+        /// Total number of files in the collection.
+        total: usize,
+        /// Relative path of the file within the collection.
+        name: String,
+    },
+    /// Byte-level progress for the current blob (raw file or collection member).
+    Bytes {
+        /// Bytes received so far.
+        done: u64,
+        /// Total expected bytes.
+        total: u64,
+    },
+}
+
 pub(crate) struct RingReceiver {
     store: FsStore,
 }
@@ -39,10 +67,11 @@ impl RingReceiver {
     /// Download `hash` (and its members if it is a `HashSeq`) over `conn`,
     /// then export the result to `dest`.
     ///
-    /// `on_progress(bytes_done, total_bytes)` is called for each received leaf
-    /// chunk.  For `HashSeq` blobs progress is reported per member file only;
-    /// the tiny metadata root is downloaded silently.
-    pub(crate) async fn download<F: Fn(u64, u64) + Send + Sync>(
+    /// For raw blobs, `on_progress` receives [`ProgressEvent::Bytes`] for each
+    /// received chunk. For `HashSeq` collections it additionally receives a
+    /// [`ProgressEvent::FileStart`] before each member file begins; the tiny
+    /// metadata root is downloaded silently.
+    pub(crate) async fn download<F: Fn(ProgressEvent) + Send + Sync>(
         &self,
         conn: &Connection,
         hash: Hash,
@@ -64,7 +93,8 @@ impl RingReceiver {
             info!(hash = %hash, "root blob received");
         }
 
-        // For collections: fetch every member blob referenced by the HashSeq.
+        // For collections: load the meta blob first (needed by Collection::load),
+        // then fetch each named member file with per-file FileStart events.
         if format == BlobFormat::HashSeq {
             let root_bytes = self
                 .store
@@ -73,10 +103,26 @@ impl RingReceiver {
                 .await
                 .context("reading root HashSeq")?;
             let hash_seq = HashSeq::try_from(root_bytes).context("parsing HashSeq")?;
-            for item_hash in hash_seq {
+
+            let mut hs_iter = hash_seq.into_iter();
+            if let Some(meta_hash) = hs_iter.next() {
+                self.fetch_blob(conn, meta_hash, None::<Arc<F>>).await?;
+            }
+
+            let collection = Collection::load(hash, &*self.store)
+                .await
+                .context("loading collection")?;
+            let file_total = collection.iter().count();
+
+            for (file_idx, (file_name, item_hash)) in collection.iter().enumerate() {
                 info!(item_hash = %item_hash, "fetching collection item");
-                let op = Arc::clone(&on_progress);
-                self.fetch_blob(conn, item_hash, Some(op)).await?;
+                on_progress(ProgressEvent::FileStart {
+                    index: file_idx + 1,
+                    total: file_total,
+                    name: file_name.to_owned(),
+                });
+                self.fetch_blob(conn, *item_hash, Some(Arc::clone(&on_progress)))
+                    .await?;
             }
         }
 
@@ -88,7 +134,7 @@ impl RingReceiver {
     /// Skips silently if the blob is already complete in the local store.
     /// `on_progress` is `None` when the caller wants to suppress progress
     /// reporting (e.g. for the tiny HashSeq metadata root).
-    async fn fetch_blob<F: Fn(u64, u64) + Send + Sync>(
+    async fn fetch_blob<F: Fn(ProgressEvent) + Send + Sync>(
         &self,
         conn: &Connection,
         hash: Hash,
@@ -128,7 +174,7 @@ impl RingReceiver {
             .context("reading bao size header")?;
         let content_size = u64::from_le_bytes(size_buf);
         if let Some(ref p) = on_progress {
-            p(0, content_size);
+            p(ProgressEvent::Bytes { done: 0, total: content_size });
         }
 
         if let Some(size) = NonZeroU64::new(content_size) {
@@ -156,7 +202,10 @@ impl RingReceiver {
                             let item = item.map_err(io::Error::other)?;
                             if let BaoContentItem::Leaf(ref leaf) = item {
                                 if let Some(ref p) = on_progress {
-                                    p(leaf.offset + leaf.data.len() as u64, content_size);
+                                    p(ProgressEvent::Bytes {
+                                        done: leaf.offset + leaf.data.len() as u64,
+                                        total: content_size,
+                                    });
                                 }
                             }
                             tx.send(item).await.map_err(io::Error::from)?;

--- a/src/daemon/client.rs
+++ b/src/daemon/client.rs
@@ -94,7 +94,10 @@ impl DaemonClient {
         self.send(op, |event| match event.kind {
             EventKind::Line { text } => println!("{text}"),
             EventKind::Error { message } => err = Some(message),
-            EventKind::Done | EventKind::Progress { .. } | EventKind::Record { .. } => {}
+            EventKind::Done
+            | EventKind::Progress { .. }
+            | EventKind::FileProgress { .. }
+            | EventKind::Record { .. } => {}
         })
         .await?;
         if let Some(msg) = err {

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -239,6 +239,19 @@ pub enum EventKind {
         /// Total expected bytes.
         total: u64,
     },
+    /// Per-file progress during a directory blob (`HashSeq`) transfer.
+    FileProgress {
+        /// 1-based index of the current file in the collection.
+        file_index: usize,
+        /// Total number of files in the collection.
+        file_total: usize,
+        /// Relative path of the file within the collection.
+        file_name: String,
+        /// Bytes received so far for this file.
+        done: u64,
+        /// Total size of this file in bytes.
+        total: u64,
+    },
     /// Signal of request completed successfully; no further events will follow for this req_id.
     Done,
     /// Signal of request failed; no further events will follow for this req_id.
@@ -302,6 +315,27 @@ impl Event {
         Self {
             req_id,
             kind: EventKind::Record { value },
+        }
+    }
+
+    /// Constructs a [`EventKind::FileProgress`] event for a directory transfer.
+    pub fn file_progress(
+        req_id: Uuid,
+        file_index: usize,
+        file_total: usize,
+        file_name: impl Into<String>,
+        done: u64,
+        total: u64,
+    ) -> Self {
+        Self {
+            req_id,
+            kind: EventKind::FileProgress {
+                file_index,
+                file_total,
+                file_name: file_name.into(),
+                done,
+                total,
+            },
         }
     }
 }
@@ -402,6 +436,15 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&Event::progress(id, 50, 100)).unwrap(),
             r#"{"req_id":"550e8400-e29b-41d4-a716-446655440000","type":"progress","done":50,"total":100}"#
+        );
+    }
+
+    #[test]
+    fn event_file_progress_serializes_correctly() {
+        let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
+        assert_eq!(
+            serde_json::to_string(&Event::file_progress(id, 1, 3, "readme.txt", 50, 100)).unwrap(),
+            r#"{"req_id":"550e8400-e29b-41d4-a716-446655440000","type":"file_progress","file_index":1,"file_total":3,"file_name":"readme.txt","done":50,"total":100}"#
         );
     }
 

--- a/src/daemon/server/handlers/blob.rs
+++ b/src/daemon/server/handlers/blob.rs
@@ -168,21 +168,21 @@ pub(crate) async fn handle_blob_list<R: Registry + Clone + Send + Sync + 'static
                 )
                 .await;
             } else {
-                let names: Vec<_> =
-                    blob_rings.iter().map(|(r, _)| r.as_str().to_owned()).collect();
+                let names: Vec<_> = blob_rings
+                    .iter()
+                    .map(|(r, _)| r.as_str().to_owned())
+                    .collect();
                 send(
                     tx,
                     Event::line(req_id, format!("    rings:  {}", names.join(", "))),
                 )
                 .await;
             }
-            send(
-                tx,
-                Event::line(req_id, format!("    ticket: {ticket_str}")),
-            )
-            .await;
-            let ring_names: Vec<_> =
-                blob_rings.iter().map(|(r, _)| r.as_str().to_owned()).collect();
+            send(tx, Event::line(req_id, format!("    ticket: {ticket_str}"))).await;
+            let ring_names: Vec<_> = blob_rings
+                .iter()
+                .map(|(r, _)| r.as_str().to_owned())
+                .collect();
             send(
                 tx,
                 Event::record(

--- a/src/daemon/server/handlers/blob.rs
+++ b/src/daemon/server/handlers/blob.rs
@@ -130,35 +130,69 @@ pub(crate) async fn handle_blob_list<R: Registry + Clone + Send + Sync + 'static
         .await;
     } else {
         send(tx, Event::line(req_id, format!("{} blobs:", blobs.len()))).await;
-        for (hash, format, name) in blobs {
-            let rings = node.registry.list_resource_rings(*hash.as_bytes())?;
-            let ticket = node.make_ticket(hash, format, Some(name.clone()));
+        for entry in blobs {
+            let blob_rings = node.registry.list_resource_rings(*entry.hash.as_bytes())?;
+            let ticket = node.make_ticket(entry.hash, entry.format, Some(entry.name.clone()));
             let ticket_str = ticket.to_uri()?;
+
+            let kind_str = match entry.format {
+                iroh_blobs::BlobFormat::HashSeq => {
+                    let count = entry
+                        .file_count
+                        .map(|n| format!("{n} files"))
+                        .unwrap_or_else(|| "dir".into());
+                    format!("dir, {count}")
+                }
+                _ => "file".into(),
+            };
+            let size_str = entry
+                .total_size
+                .map(format_size)
+                .unwrap_or_else(|| "?".into());
+
             send(tx, Event::blank(req_id)).await;
-            send(tx, Event::line(req_id, format!("  {hash}  ({name})"))).await;
-            if rings.is_empty() {
+            send(
+                tx,
+                Event::line(req_id, format!("  {}  ({})", entry.hash, entry.name)),
+            )
+            .await;
+            send(
+                tx,
+                Event::line(req_id, format!("    kind:   {kind_str}  ({size_str})")),
+            )
+            .await;
+            if blob_rings.is_empty() {
                 send(
                     tx,
-                    Event::line(req_id, "    no rings:  (inaccessible for all peers)"),
+                    Event::line(req_id, "    rings:  (none — inaccessible to all peers)"),
                 )
                 .await;
             } else {
-                let names: Vec<_> = rings.iter().map(|(r, _)| r.as_str().to_owned()).collect();
+                let names: Vec<_> =
+                    blob_rings.iter().map(|(r, _)| r.as_str().to_owned()).collect();
                 send(
                     tx,
                     Event::line(req_id, format!("    rings:  {}", names.join(", "))),
                 )
                 .await;
             }
-            send(tx, Event::line(req_id, format!("    ticket: {ticket_str}"))).await;
-            let ring_names: Vec<_> = rings.iter().map(|(r, _)| r.as_str().to_owned()).collect();
+            send(
+                tx,
+                Event::line(req_id, format!("    ticket: {ticket_str}")),
+            )
+            .await;
+            let ring_names: Vec<_> =
+                blob_rings.iter().map(|(r, _)| r.as_str().to_owned()).collect();
             send(
                 tx,
                 Event::record(
                     req_id,
                     serde_json::json!({
-                        "hash": hash.to_string(),
-                        "name": name,
+                        "hash": entry.hash.to_string(),
+                        "name": entry.name,
+                        "kind": kind_str,
+                        "file_count": entry.file_count,
+                        "size_bytes": entry.total_size,
                         "rings": ring_names,
                         "ticket": ticket_str,
                     }),
@@ -169,6 +203,21 @@ pub(crate) async fn handle_blob_list<R: Registry + Clone + Send + Sync + 'static
     }
     send(tx, Event::done(req_id)).await;
     Ok(())
+}
+
+fn format_size(bytes: u64) -> String {
+    const KIB: u64 = 1024;
+    const MIB: u64 = 1024 * KIB;
+    const GIB: u64 = 1024 * MIB;
+    if bytes >= GIB {
+        format!("{:.1} GiB", bytes as f64 / GIB as f64)
+    } else if bytes >= MIB {
+        format!("{:.1} MiB", bytes as f64 / MIB as f64)
+    } else if bytes >= KIB {
+        format!("{:.1} KiB", bytes as f64 / KIB as f64)
+    } else {
+        format!("{bytes} B")
+    }
 }
 
 pub(crate) async fn handle_blob_remove<R: Registry + Clone + Send + Sync + 'static>(

--- a/src/daemon/server/handlers/receive.rs
+++ b/src/daemon/server/handlers/receive.rs
@@ -68,8 +68,7 @@ pub(crate) async fn handle_receive<R: Registry + Clone + Send + Sync + 'static>(
     // Progress events are emitted by a separate task so they don't block the
     // download future — `on_progress` is `Fn` (not async), so it can't await
     // the channel send directly.
-    let (progress_tx, mut progress_rx) =
-        tokio::sync::mpsc::unbounded_channel::<ProgressEvent>();
+    let (progress_tx, mut progress_rx) = tokio::sync::mpsc::unbounded_channel::<ProgressEvent>();
     let on_progress = move |ev: ProgressEvent| {
         let _ = progress_tx.send(ev);
     };

--- a/src/daemon/server/handlers/receive.rs
+++ b/src/daemon/server/handlers/receive.rs
@@ -5,7 +5,7 @@ use iroh_rings::Registry;
 use tokio::sync::mpsc;
 use uuid::Uuid;
 
-use crate::core::{Node, ShareTicket};
+use crate::core::{Node, ProgressEvent, ShareTicket};
 use crate::daemon::protocol::Event;
 
 use super::send;
@@ -68,15 +68,29 @@ pub(crate) async fn handle_receive<R: Registry + Clone + Send + Sync + 'static>(
     // Progress events are emitted by a separate task so they don't block the
     // download future — `on_progress` is `Fn` (not async), so it can't await
     // the channel send directly.
-    let (progress_tx, mut progress_rx) = tokio::sync::mpsc::unbounded_channel::<(u64, u64)>();
-    let on_progress = move |done: u64, total: u64| {
-        let _ = progress_tx.send((done, total));
+    let (progress_tx, mut progress_rx) =
+        tokio::sync::mpsc::unbounded_channel::<ProgressEvent>();
+    let on_progress = move |ev: ProgressEvent| {
+        let _ = progress_tx.send(ev);
     };
 
     let event_tx = tx.clone();
     let progress_task = tokio::spawn(async move {
-        while let Some((done, total)) = progress_rx.recv().await {
-            let _ = event_tx.send(Event::progress(req_id, done, total)).await;
+        let mut current_file: Option<(usize, usize, String)> = None;
+        while let Some(ev) = progress_rx.recv().await {
+            match ev {
+                ProgressEvent::FileStart { index, total, name } => {
+                    current_file = Some((index, total, name));
+                }
+                ProgressEvent::Bytes { done, total } => {
+                    let ipc_ev = if let Some((fi, ft, ref fname)) = current_file {
+                        Event::file_progress(req_id, fi, ft, fname.clone(), done, total)
+                    } else {
+                        Event::progress(req_id, done, total)
+                    };
+                    let _ = event_tx.send(ipc_ev).await;
+                }
+            }
         }
     });
 

--- a/tests/blob_management.rs
+++ b/tests/blob_management.rs
@@ -1,5 +1,6 @@
 mod common;
 
+use iroh_blobs::BlobFormat;
 use iroh_rings::{Permission, Registry, OPEN_RING_NAME};
 use tempfile::TempDir;
 
@@ -12,8 +13,8 @@ async fn import_file_preserves_filename_in_tag() {
     let (hash, _format) = node.node.import_file(&file).await.unwrap();
 
     let blobs = node.node.list_blobs(None, None).await.unwrap();
-    let (_, _, name) = blobs.into_iter().find(|(h, _, _)| *h == hash).unwrap();
-    assert_eq!(name, "report.pdf");
+    let entry = blobs.into_iter().find(|e| e.hash == hash).unwrap();
+    assert_eq!(entry.name, "report.pdf");
 
     node.shutdown().await;
 }
@@ -30,8 +31,8 @@ async fn import_directory_preserves_dir_name_in_tag() {
     let (hash, _format) = node.node.import_directory(&named_dir).await.unwrap();
 
     let blobs = node.node.list_blobs(None, None).await.unwrap();
-    let (_, _, name) = blobs.into_iter().find(|(h, _, _)| *h == hash).unwrap();
-    assert_eq!(name, "my_dataset");
+    let entry = blobs.into_iter().find(|e| e.hash == hash).unwrap();
+    assert_eq!(entry.name, "my_dataset");
 
     node.shutdown().await;
 }
@@ -59,16 +60,71 @@ async fn list_blobs_ticket_carries_original_filename() {
 
     let (hash, _format) = node.node.import_file(&file).await.unwrap();
 
-    let (_, fmt, name) = node
+    let entry = node
         .node
         .list_blobs(None, None)
         .await
         .unwrap()
         .into_iter()
-        .find(|(h, _, _)| *h == hash)
+        .find(|e| e.hash == hash)
         .unwrap();
-    let ticket = node.node.make_ticket(hash, fmt, Some(name));
+    let ticket = node.node.make_ticket(hash, entry.format, Some(entry.name));
     assert_eq!(ticket.name.as_deref(), Some("video.mp4"));
+
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn blob_list_entry_for_file_shows_format_and_size() {
+    let node = common::TestNode::start().await;
+    let src = TempDir::new().unwrap();
+    let content = b"hello world";
+    let file = common::write_file(src.path(), "test.txt", content).await;
+
+    let (hash, _) = node.node.import_file(&file).await.unwrap();
+
+    let entry = node
+        .node
+        .list_blobs(None, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|e| e.hash == hash)
+        .unwrap();
+    assert_eq!(entry.format, BlobFormat::Raw);
+    assert_eq!(entry.file_count, None);
+    assert_eq!(entry.total_size, Some(content.len() as u64));
+
+    node.shutdown().await;
+}
+
+#[tokio::test]
+async fn blob_list_entry_for_directory_shows_file_count_and_total_size() {
+    let node = common::TestNode::start().await;
+    let src = TempDir::new().unwrap();
+    let dir = src.path().join("mydir");
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+    let content_a = b"aaa";
+    let content_b = b"bbbb";
+    common::write_file(&dir, "a.txt", content_a).await;
+    common::write_file(&dir, "b.txt", content_b).await;
+
+    let (hash, _) = node.node.import_directory(&dir).await.unwrap();
+
+    let entry = node
+        .node
+        .list_blobs(None, None)
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|e| e.hash == hash)
+        .unwrap();
+    assert_eq!(entry.format, BlobFormat::HashSeq);
+    assert_eq!(entry.file_count, Some(2));
+    assert_eq!(
+        entry.total_size,
+        Some((content_a.len() + content_b.len()) as u64)
+    );
 
     node.shutdown().await;
 }

--- a/tests/transfer.rs
+++ b/tests/transfer.rs
@@ -109,12 +109,14 @@ async fn directory_transfer_emits_file_start_events_per_member() {
         .await
         .unwrap();
 
-    let starts = file_starts.lock().unwrap();
-    assert_eq!(starts.len(), 2, "expected one FileStart per member file");
-    assert!(starts.iter().all(|(_, t, _)| *t == 2));
-    let names: Vec<&str> = starts.iter().map(|(_, _, n)| n.as_str()).collect();
-    assert!(names.contains(&"a.jpg"));
-    assert!(names.contains(&"b.jpg"));
+    {
+        let starts = file_starts.lock().unwrap();
+        assert_eq!(starts.len(), 2, "expected one FileStart per member file");
+        assert!(starts.iter().all(|(_, t, _)| *t == 2));
+        let names: Vec<&str> = starts.iter().map(|(_, _, n)| n.as_str()).collect();
+        assert!(names.contains(&"a.jpg"));
+        assert!(names.contains(&"b.jpg"));
+    }
 
     sender.shutdown().await;
     receiver.shutdown().await;

--- a/tests/transfer.rs
+++ b/tests/transfer.rs
@@ -96,8 +96,7 @@ async fn directory_transfer_emits_file_start_events_per_member() {
     let ticket = sender.node.make_ticket(hash, format, Some("photos".into()));
     let dest = TempDir::new().unwrap();
 
-    let file_starts: Arc<Mutex<Vec<(usize, usize, String)>>> =
-        Arc::new(Mutex::new(Vec::new()));
+    let file_starts: Arc<Mutex<Vec<(usize, usize, String)>>> = Arc::new(Mutex::new(Vec::new()));
     let file_starts_clone = Arc::clone(&file_starts);
 
     receiver

--- a/tests/transfer.rs
+++ b/tests/transfer.rs
@@ -1,6 +1,10 @@
 mod common;
 
+use std::sync::{Arc, Mutex};
+
+use iroh_blobs::BlobFormat;
 use iroh_rings::{Permission, Registry, OPEN_RING_NAME};
+use ringdrop::core::ProgressEvent;
 use tempfile::TempDir;
 
 #[tokio::test]
@@ -65,6 +69,53 @@ async fn directory_contents_match_after_transfer() {
         tokio::fs::read(out.join("data.bin")).await.unwrap(),
         b"\x00\x01\x02\x03"
     );
+
+    sender.shutdown().await;
+    receiver.shutdown().await;
+}
+
+#[tokio::test]
+async fn directory_transfer_emits_file_start_events_per_member() {
+    let sender = common::TestNode::start().await;
+    let receiver = common::TestNode::start().await;
+
+    let src = TempDir::new().unwrap();
+    let dir = src.path().join("photos");
+    tokio::fs::create_dir_all(&dir).await.unwrap();
+    common::write_file(&dir, "a.jpg", b"img-a").await;
+    common::write_file(&dir, "b.jpg", b"img-b").await;
+
+    let (hash, format) = sender.node.import_directory(&dir).await.unwrap();
+    assert_eq!(format, BlobFormat::HashSeq);
+    sender
+        .node
+        .registry
+        .add_ring_to_resource(*hash.as_bytes(), OPEN_RING_NAME, &[Permission::Read])
+        .unwrap();
+
+    let ticket = sender.node.make_ticket(hash, format, Some("photos".into()));
+    let dest = TempDir::new().unwrap();
+
+    let file_starts: Arc<Mutex<Vec<(usize, usize, String)>>> =
+        Arc::new(Mutex::new(Vec::new()));
+    let file_starts_clone = Arc::clone(&file_starts);
+
+    receiver
+        .node
+        .download_with_progress(&ticket, dest.path(), move |ev| {
+            if let ProgressEvent::FileStart { index, total, name } = ev {
+                file_starts_clone.lock().unwrap().push((index, total, name));
+            }
+        })
+        .await
+        .unwrap();
+
+    let starts = file_starts.lock().unwrap();
+    assert_eq!(starts.len(), 2, "expected one FileStart per member file");
+    assert!(starts.iter().all(|(_, t, _)| *t == 2));
+    let names: Vec<&str> = starts.iter().map(|(_, _, n)| n.as_str()).collect();
+    assert!(names.contains(&"a.jpg"));
+    assert!(names.contains(&"b.jpg"));
 
     sender.shutdown().await;
     receiver.shutdown().await;


### PR DESCRIPTION
Closes #20.

### Core layer:

- `protocol/rings.rs`: added `ProgressEvent` enum and updated download and fetch_blob to use it (directory downloads now download the meta blob silently).

- protocol/mod.rs: re-exports ProgressEvent.

- `node.rs`: added `BlobListEntry { hash, format, name, file_count, total_size }` for blob listing.

### Daemon layer

- `protocol.rs`: added `EventKind::FileProgress` `{ file_index, file_total, file_name, done, total }` variant + `Event::file_progress` constructor + serialization test.

- `handlers/blob.rs`: handle_blob_list updated to use `BlobListEntry` fields, showing kind (file/dir with count) and formatted size.

- `handlers/receive.rs`: the progress channel now carries `ProgressEvent`.

### CLI

- `command/receive.rs`: added `{msg}` to the progress bar template.
