### PR TITLE
feat(CLI): add ASCII QR-code to id command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3127,6 +3127,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quick-xml"
 version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3447,6 +3453,7 @@ dependencies = [
  "iroh-blobs",
  "iroh-io",
  "iroh-rings",
+ "qrcode",
  "redb",
  "reqwest",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ indicatif = "0.18"            # terminal progress bars
 serde_millis = "0.1.1"
 uuid = { version = "1", features = ["v4", "serde"] }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
+qrcode = { version = "0.14.1", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -14,6 +14,8 @@ Print this node's peer-id (its public key in base32). Share it with others so th
 rdrop id
 ```
 
+If you specify the `--qr-code` flag, an ASCII QR-code is generated and printed to your console, representing your peer-id.
+
 ---
 
 ## `rdrop daemon`

--- a/src/cli/command/daemon.rs
+++ b/src/cli/command/daemon.rs
@@ -160,7 +160,7 @@ async fn query_node_info(client: &DaemonClient) -> Result<String> {
     let mut node_id = String::new();
     let mut err: Option<String> = None;
     client
-        .send(Op::NodeId, |event| match event.kind {
+        .send(Op::NodeId { qr_code: false }, |event| match event.kind {
             EventKind::Line { text } => node_id = text,
             EventKind::Error { message } => err = Some(message),
             _ => {}

--- a/src/cli/command/id.rs
+++ b/src/cli/command/id.rs
@@ -4,6 +4,8 @@ use anyhow::Result;
 
 use crate::daemon::protocol::Op;
 
-pub(crate) async fn run(data_dir: &Path) -> Result<()> {
-    super::daemon_client(data_dir)?.run(Op::NodeId).await
+pub(crate) async fn run(qr_code: bool, data_dir: &Path) -> Result<()> {
+    super::daemon_client(data_dir)?
+        .run(Op::NodeId { qr_code })
+        .await
 }

--- a/src/cli/command/mod.rs
+++ b/src/cli/command/mod.rs
@@ -76,8 +76,11 @@ pub(super) enum Cmd {
     Remote(RemoteCmd),
 
     /// Print your peer-id (i.e. this node public-id) so others can add you to their rings
-    Id,
-
+    Id {
+        /// Show the ASCII QR-code below the peer-id
+        #[arg(long)]
+        qr_code: bool,
+    },
     /// Decode a ticket and display its fields (hash, peer, relays, format, name)
     Info {
         /// Ticket string (rdrop://...)

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -10,6 +10,7 @@
 //!
 //! # Print your peer-id so others can add you to their rings
 //! rdrop id
+//! rdrop id --qr-code                   # also shows an ASCII qr-code representing your peer-id
 //!
 //! # Manage rings
 //! rdrop ring new friends               # create a ring named "friends"
@@ -142,7 +143,7 @@ pub async fn run() -> Result<()> {
         }
         Cmd::Grant(cmd) => command::grant::run(cmd, &data_dir).await?,
         Cmd::Remote(cmd) => command::remote::run(cmd, &data_dir).await?,
-        Cmd::Id => command::id::run(&data_dir).await?,
+        Cmd::Id { qr_code } => command::id::run(qr_code, &data_dir).await?,
         Cmd::Info { ticket } => command::info::run(&ticket)?,
     }
 

--- a/src/daemon/protocol.rs
+++ b/src/daemon/protocol.rs
@@ -32,7 +32,10 @@ pub enum Op {
     /// Returns this node's [`EndpointId`] as a hex string.
     ///
     /// [`EndpointId`]: iroh::EndpointId
-    NodeId,
+    NodeId {
+        /// Also render an ASCII QR-code of the peer-id, streamed as extra [`EventKind::Line`]s.
+        qr_code: bool,
+    },
     /// Imports a file or directory and tags it with the given rings.
     Import {
         /// Path to the file or directory to import.
@@ -347,8 +350,8 @@ mod tests {
     #[test]
     fn op_node_id_serializes_to_snake_case_tag() {
         assert_eq!(
-            serde_json::to_string(&Op::NodeId).unwrap(),
-            r#"{"op":"node_id"}"#
+            serde_json::to_string(&Op::NodeId { qr_code: false }).unwrap(),
+            r#"{"op":"node_id","qr_code":false}"#
         );
     }
 
@@ -393,20 +396,22 @@ mod tests {
 
     #[test]
     fn request_without_req_id_fails_to_deserialize() {
-        let result: Result<Request, _> = serde_json::from_str(r#"{"op":"node_id"}"#);
+        let result: Result<Request, _> =
+            serde_json::from_str(r#"{"op":"node_id","qr_code":false}"#);
         assert!(result.is_err());
     }
 
     #[test]
     fn request_with_empty_req_id_fails_to_deserialize() {
-        let result: Result<Request, _> = serde_json::from_str(r#"{"req_id":"","op":"node_id"}"#);
+        let result: Result<Request, _> =
+            serde_json::from_str(r#"{"req_id":"","op":"node_id","qr_code":false}"#);
         assert!(result.is_err());
     }
 
     #[test]
     fn request_with_malformed_req_id_fails_to_deserialize() {
         let result: Result<Request, _> =
-            serde_json::from_str(r#"{"req_id":"not-a-uuid","op":"node_id"}"#);
+            serde_json::from_str(r#"{"req_id":"not-a-uuid","op":"node_id","qr_code":false}"#);
         assert!(result.is_err());
     }
 

--- a/src/daemon/server/mod.rs
+++ b/src/daemon/server/mod.rs
@@ -14,9 +14,11 @@ mod handlers;
 use std::sync::Arc;
 use std::time::Duration;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use futures_lite::StreamExt;
 use iroh_rings::Registry;
+use qrcode::render::unicode;
+use qrcode::QrCode;
 use tokio::io::AsyncWriteExt;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, Notify};
@@ -220,9 +222,17 @@ async fn handle_op<R: Registry + Clone + Send + Sync + 'static>(
     tx: &mpsc::Sender<Event>,
 ) -> Result<()> {
     match op {
-        Op::NodeId => {
+        Op::NodeId { qr_code } => {
             let peer_id = node.endpoint.id();
             let _ = tx.send(Event::line(req_id, peer_id.to_string())).await;
+            if qr_code {
+                let code = QrCode::new(peer_id.to_string())
+                    .context("failed to generate QR code for peer-id")?;
+                let art = code.render::<unicode::Dense1x2>().quiet_zone(true).build();
+                let lines: Vec<String> = art.lines().map(str::to_owned).collect();
+                let _ = tx.send(Event::blank(req_id)).await;
+                send_lines(tx, req_id, &lines).await;
+            }
             let _ = tx
                 .send(Event::record(
                     req_id,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -102,7 +102,7 @@ pub async fn daemon_contract(daemon: TestDaemon) {
     let mut lines: Vec<String> = Vec::new();
     daemon
         .client
-        .send(Op::NodeId, |event| {
+        .send(Op::NodeId { qr_code: false }, |event| {
             if let EventKind::Line { text } = event.kind {
                 lines.push(text);
             }

--- a/tests/daemon.rs
+++ b/tests/daemon.rs
@@ -26,13 +26,40 @@ async fn daemon_contract_holds_with_redb() {
 }
 
 #[tokio::test]
+async fn node_id_with_qr_code_emits_peer_id_then_qr_art_lines() {
+    let daemon = common::TestDaemon::start().await;
+
+    let mut lines: Vec<String> = Vec::new();
+    daemon
+        .client
+        .send(Op::NodeId { qr_code: true }, |event| {
+            if let EventKind::Line { text } = event.kind {
+                lines.push(text);
+            }
+        })
+        .await
+        .unwrap();
+
+    assert!(
+        lines.len() > 2,
+        "expected the peer-id line plus a blank line and QR art lines, got {lines:?}"
+    );
+    assert!(!lines[0].is_empty(), "first line must be the peer-id");
+    assert_eq!(lines[1], "", "second line must be a blank separator");
+    assert!(
+        lines[2..].iter().any(|l| !l.is_empty()),
+        "remaining lines must contain rendered QR art"
+    );
+}
+
+#[tokio::test]
 async fn ring_add_self_is_rejected_via_daemon() {
     let daemon = common::TestDaemon::start().await;
 
     let mut node_id = String::new();
     daemon
         .client
-        .send(Op::NodeId, |event| {
+        .send(Op::NodeId { qr_code: false }, |event| {
             if let EventKind::Line { text } = event.kind {
                 node_id = text;
             }
@@ -351,7 +378,7 @@ async fn grant_add_then_list_shows_the_grant() {
     let mut peer_id = String::new();
     daemon
         .client
-        .send(Op::NodeId, |event| {
+        .send(Op::NodeId { qr_code: false }, |event| {
             if let EventKind::Line { text } = event.kind {
                 peer_id = text;
             }
@@ -395,7 +422,7 @@ async fn grant_revoke_removes_grant_from_list() {
     let mut peer_id = String::new();
     daemon
         .client
-        .send(Op::NodeId, |event| {
+        .send(Op::NodeId { qr_code: false }, |event| {
             if let EventKind::Line { text } = event.kind {
                 peer_id = text;
             }


### PR DESCRIPTION
Closes #42

If the `--qr-code` flag is passed to the `id` command, a QR-code is generated and shown below the peer-id.